### PR TITLE
add support for user-configured font

### DIFF
--- a/src/src/mainwindow.cpp
+++ b/src/src/mainwindow.cpp
@@ -764,6 +764,22 @@ void MainWindow::updateStyle(const QString&)
 {
   resetActionIcons();
   resetButtonIcons();
+
+  // Font may have changed — force list views to re-query item roles.
+  // This runs via direct connection before the queued setStyleFile(),
+  // so defer until the next event-loop iteration so the font is applied first.
+  QTimer::singleShot(0, [this] {
+    QFont newFont = QApplication::font();
+    auto refresh = [&](QTreeView* view) {
+      view->setFont(newFont);
+      view->header()->resizeSections(QHeaderView::ResizeToContents);
+    };
+    refresh(ui->modList);
+    refresh(ui->espList);
+    refresh(ui->dataTree);
+    refresh(ui->downloadView);
+    refresh(ui->logList);
+  });
 }
 
 void MainWindow::resizeEvent(QResizeEvent* event)

--- a/src/src/moapplication.cpp
+++ b/src/src/moapplication.cpp
@@ -764,8 +764,13 @@ bool MOApplication::setStyleFile(const QString& styleName)
 
     const QString fontFamily =
         m_settings != nullptr ? m_settings->interface().fontFamily() : QString();
+    const int fontSize =
+        m_settings != nullptr ? m_settings->interface().qssFontSize() : 0;
     QFont appFont = QApplication::font();
     appFont.setFamily(!fontFamily.isEmpty() ? fontFamily : m_defaultFontFamily);
+    if (fontSize > 0) {
+      appFont.setPixelSize(fontSize);
+    }
     QApplication::setFont(appFont);
   }
   return true;
@@ -1058,11 +1063,14 @@ void MOApplication::updateStyle(const QString& fileName)
     }
   }
 
-  // Apply user's font family override (or fall back to bundled DejaVu Sans)
+  // Apply user's font family/size override (or fall back to bundled DejaVu Sans)
   const QString fontFamily =
       m_settings != nullptr ? m_settings->interface().fontFamily() : QString();
   QFont appFont = QApplication::font();
   appFont.setFamily(!fontFamily.isEmpty() ? fontFamily : m_defaultFontFamily);
+  if (qssFontSize > 0) {
+    appFont.setPixelSize(qssFontSize);
+  }
   QApplication::setFont(appFont);
 }
 

--- a/src/src/moapplication.cpp
+++ b/src/src/moapplication.cpp
@@ -137,7 +137,7 @@ void addLinuxLibrariesToPath()
   env::prependToPath(libsPath);
 }
 
-void configureApplicationFont()
+QString configureApplicationFont()
 {
   const QDir fontDir(QCoreApplication::applicationDirPath() + "/fonts");
   const QStringList bundledFonts{
@@ -165,6 +165,8 @@ void configureApplicationFont()
     font.setFamily(uiFamily);
     QApplication::setFont(font);
   }
+
+  return uiFamily;
 }
 
 #ifdef MO2_WEBENGINE
@@ -237,7 +239,7 @@ void configureQtWebEngineProcessPath()
 MOApplication::MOApplication(int& argc, char** argv) : QApplication(argc, argv)
 {
   TimeThis const tt("MOApplication()");
-  configureApplicationFont();
+  m_defaultFontFamily = configureApplicationFont();
 
   // Ensure the app name is always "ModOrganizer" regardless of the binary
   // filename (settings/profile lookups key off this).
@@ -759,6 +761,12 @@ bool MOApplication::setStyleFile(const QString& styleName)
   } else {
     setStyle(new ProxyStyle(QStyleFactory::create(m_defaultStyle)));
     setStyleSheet("");
+
+    const QString fontFamily =
+        m_settings != nullptr ? m_settings->interface().fontFamily() : QString();
+    QFont appFont = QApplication::font();
+    appFont.setFamily(!fontFamily.isEmpty() ? fontFamily : m_defaultFontFamily);
+    QApplication::setFont(appFont);
   }
   return true;
 }
@@ -1049,6 +1057,13 @@ void MOApplication::updateStyle(const QString& fileName)
       log::warn("invalid stylesheet: {}", fileName);
     }
   }
+
+  // Apply user's font family override (or fall back to bundled DejaVu Sans)
+  const QString fontFamily =
+      m_settings != nullptr ? m_settings->interface().fontFamily() : QString();
+  QFont appFont = QApplication::font();
+  appFont.setFamily(!fontFamily.isEmpty() ? fontFamily : m_defaultFontFamily);
+  QApplication::setFont(appFont);
 }
 
 MOSplash::MOSplash(const Settings& settings, const QString& dataPath,

--- a/src/src/moapplication.h
+++ b/src/src/moapplication.h
@@ -79,6 +79,7 @@ private slots:
 private:
   QFileSystemWatcher m_styleWatcher;
   QString m_defaultStyle;
+  QString m_defaultFontFamily;
   std::unique_ptr<env::ModuleNotification> m_modules;
 
   std::unique_ptr<Instance> m_instance;

--- a/src/src/settings.cpp
+++ b/src/src/settings.cpp
@@ -2142,6 +2142,16 @@ void InterfaceSettings::setQssFontSize(int size)
   set(m_Settings, "Settings", "qss_font_size", size);
 }
 
+QString InterfaceSettings::fontFamily() const
+{
+  return get<QString>(m_Settings, "Settings", "font_family", "");
+}
+
+void InterfaceSettings::setFontFamily(const QString& family)
+{
+  set(m_Settings, "Settings", "font_family", family);
+}
+
 bool InterfaceSettings::collapsibleSeparators(Qt::SortOrder order) const
 {
   return get<bool>(m_Settings, "Settings",

--- a/src/src/settings.h
+++ b/src/src/settings.h
@@ -595,6 +595,11 @@ public:
   int qssFontSize() const;
   void setQssFontSize(int size);
 
+  // UI font family override; empty means use the bundled DejaVu Sans
+  //
+  QString fontFamily() const;
+  void setFontFamily(const QString& family);
+
   // whether to use collapsible separators when possible
   //
   bool collapsibleSeparators(Qt::SortOrder order) const;

--- a/src/src/settingsdialog.ui
+++ b/src/src/settingsdialog.ui
@@ -464,10 +464,30 @@
             <property name="maximum">
              <number>48</number>
             </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_5">
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="fontFamilyLabel">
+             <property name="text">
+              <string>Font</string>
+             </property>
+             <property name="buddy">
+              <cstring>fontFamilyCombo</cstring>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="fontFamilyCombo">
+             <property name="minimumContentsLength">
+              <number>20</number>
+             </property>
+             <property name="toolTip">
+              <string>UI font family. Default uses the bundled DejaVu Sans font.</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_5">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>

--- a/src/src/settingsdialogtheme.cpp
+++ b/src/src/settingsdialogtheme.cpp
@@ -7,6 +7,8 @@
 #include "ui_settingsdialog.h"
 #include "fluorinepaths.h"
 
+#include <QFontDatabase>
+
 #include <questionboxmemory.h>
 #include <utility.h>
 
@@ -18,6 +20,8 @@ ThemeSettingsTab::ThemeSettingsTab(Settings& s, SettingsDialog& d) : SettingsTab
   addStyles();
   selectStyle();
   selectQssFontSize();
+  populateFontFamilies();
+  selectFontFamily();
 
   // colors
   ui->colorTable->load(s);
@@ -39,6 +43,9 @@ void ThemeSettingsTab::update()
       ui->styleBox->itemData(ui->styleBox->currentIndex()).toString();
   const int oldQssFontSize = settings().interface().qssFontSize();
   const int newQssFontSize = ui->qssFontSizeSpinBox->value();
+  const QString oldFontFamily = settings().interface().fontFamily();
+  const QString newFontFamily =
+      ui->fontFamilyCombo->itemData(ui->fontFamilyCombo->currentIndex()).toString();
 
   if (oldStyle != newStyle) {
     settings().interface().setStyleName(newStyle);
@@ -48,7 +55,12 @@ void ThemeSettingsTab::update()
     settings().interface().setQssFontSize(newQssFontSize);
   }
 
-  if (oldStyle != newStyle || oldQssFontSize != newQssFontSize) {
+  if (oldFontFamily != newFontFamily) {
+    settings().interface().setFontFamily(newFontFamily);
+  }
+
+  if (oldStyle != newStyle || oldQssFontSize != newQssFontSize ||
+      oldFontFamily != newFontFamily) {
     emit settings().styleChanged(newStyle);
   }
 
@@ -108,6 +120,26 @@ void ThemeSettingsTab::selectStyle()
 void ThemeSettingsTab::selectQssFontSize()
 {
   ui->qssFontSizeSpinBox->setValue(settings().interface().qssFontSize());
+}
+
+void ThemeSettingsTab::populateFontFamilies()
+{
+  ui->fontFamilyCombo->addItem("Default (DejaVu Sans)", QString());
+
+  QStringList families = QFontDatabase::families();
+  families.sort();
+  for (const QString& family : families) {
+    ui->fontFamilyCombo->addItem(family, family);
+  }
+}
+
+void ThemeSettingsTab::selectFontFamily()
+{
+  const QString family = settings().interface().fontFamily();
+  const int idx = ui->fontFamilyCombo->findData(family);
+  if (idx != -1) {
+    ui->fontFamilyCombo->setCurrentIndex(idx);
+  }
 }
 
 void ThemeSettingsTab::onExploreStyles()

--- a/src/src/settingsdialogtheme.cpp
+++ b/src/src/settingsdialogtheme.cpp
@@ -8,6 +8,7 @@
 #include "fluorinepaths.h"
 
 #include <QFontDatabase>
+#include <QFontInfo>
 
 #include <questionboxmemory.h>
 #include <utility.h>
@@ -20,8 +21,13 @@ ThemeSettingsTab::ThemeSettingsTab(Settings& s, SettingsDialog& d) : SettingsTab
   addStyles();
   selectStyle();
   selectQssFontSize();
+  updateDefaultFontSizeHint();
   populateFontFamilies();
   selectFontFamily();
+
+  QObject::connect(ui->styleBox, &QComboBox::currentIndexChanged, [&] {
+    updateDefaultFontSizeHint();
+  });
 
   // colors
   ui->colorTable->load(s);
@@ -120,6 +126,15 @@ void ThemeSettingsTab::selectStyle()
 void ThemeSettingsTab::selectQssFontSize()
 {
   ui->qssFontSizeSpinBox->setValue(settings().interface().qssFontSize());
+}
+
+void ThemeSettingsTab::updateDefaultFontSizeHint()
+{
+  int px = QFontInfo(QApplication::font()).pixelSize();
+  if (px > 0) {
+    ui->qssFontSizeSpinBox->setSpecialValueText(
+        QStringLiteral("Default (%1 px)").arg(px));
+  }
 }
 
 void ThemeSettingsTab::populateFontFamilies()

--- a/src/src/settingsdialogtheme.h
+++ b/src/src/settingsdialogtheme.h
@@ -19,6 +19,7 @@ private:
   void selectQssFontSize();
   void populateFontFamilies();
   void selectFontFamily();
+  void updateDefaultFontSizeHint();
   static void onExploreStyles();
 };
 

--- a/src/src/settingsdialogtheme.h
+++ b/src/src/settingsdialogtheme.h
@@ -17,6 +17,8 @@ private:
   void addStyles();
   void selectStyle();
   void selectQssFontSize();
+  void populateFontFamilies();
+  void selectFontFamily();
   static void onExploreStyles();
 };
 


### PR DESCRIPTION
Three separate changes (split up by commits to make review easier)

1. Adding a setting to the theme tab to pick any font on the user's system
2. Hooking up the font size setting to apply to the font that's configured
3. Updating some of the UI elements that were not reflecting the new font until after a restart to get updated immediately

Screenshots below, since the functionality probably matters more than the code!

## Font settings

<img width="2556" height="1344" alt="20260618_202541" src="https://github.com/user-attachments/assets/aa0da700-ff6a-4f8a-9c75-7a4c97badd20" />

(no, I don't know why the `ttf-inconsolata` package on Arch has so many different entries that show up)

## Applying settings

real big monospaced font just to make it obvious it works

<img width="2533" height="1351" alt="20260618_202652" src="https://github.com/user-attachments/assets/117bec8c-9876-4da6-ba38-88da8f9824de" />