### PR TITLE
Order OpenMW content= by loadorder.txt

### DIFF
--- a/libs/basic_games/games/game_openmw.py
+++ b/libs/basic_games/games/game_openmw.py
@@ -67,6 +67,31 @@ _VALID_DIRS = {
 }
 _PLUGIN_EXTS = {".esp", ".esm", ".omwaddon", ".omwgame", ".omwscripts"}
 
+# Kezyma's "OpenMW Player" drops an empty TES3 stub ESP next to each
+# OpenMW-native plugin so MO2's right pane can list and order it. The stub is
+# named "<plugin>.esp" (e.g. "Sun's Dusk.omwaddon.esp" for the real
+# "Sun's Dusk.omwaddon"). MO2's loadorder.txt therefore records STUB names, but
+# we emit the real files (_scan_mod skips the stubs), so a stub's rank must be
+# mapped onto the real name when sorting content= — otherwise every
+# .omwaddon/.omwscripts/.omwgame plugin is unranked and the content= sort
+# ignores master-before-dependent order (e.g. SDServiceRefusal.omwaddon before
+# its parent Sun's Dusk.omwaddon, which makes OpenMW abort on launch).
+_KEZYMA_STUB_SUFFIXES = (".omwaddon.esp", ".omwscripts.esp", ".omwgame.esp")
+
+
+def _destub_plugin_name(name: str) -> str:
+    """Return the real OpenMW-native plugin name for a Kezyma stub, else ``name``.
+
+    Strips the trailing ``.esp`` wrapper from names like
+    ``Sun's Dusk.omwaddon.esp`` -> ``Sun's Dusk.omwaddon``. Real .esp/.esm plugins
+    (no OpenMW-native stem) and names that are already real pass through
+    unchanged. The suffix check is case-insensitive; the returned name
+    preserves the original casing of the stem.
+    """
+    if name.lower().endswith(_KEZYMA_STUB_SUFFIXES):
+        return name[:-4]  # strip the trailing ".esp" wrapper
+    return name
+
 
 class OpenMWModDataChecker(mobase.ModDataChecker):
     def __init__(self):
@@ -172,7 +197,17 @@ class OpenMWGame(BasicGame):
         return out
 
     def _read_loadorder_txt(self) -> list[str]:
-        """Plugin load order from <profile>/loadorder.txt (MO2 right-pane order)."""
+        """Plugin load order from <profile>/loadorder.txt (MO2 right-pane order).
+
+        loadorder.txt records Kezyma stub names for OpenMW-native plugins (e.g.
+        ``Sun's Dusk.omwaddon.esp``), but we emit the real files (the stubs are
+        skipped in _scan_mod). Map each entry through _destub_plugin_name so the
+        returned names match the content= plugins we sort against — otherwise
+        every .omwaddon/.omwscripts/.omwgame plugin is unranked and the sort
+        falls back to scan order, ignoring master-before-dependent ordering
+        (e.g. SDServiceRefusal.omwaddon before its parent Sun's Dusk.omwaddon,
+        which makes OpenMW abort on launch).
+        """
         try:
             profile_dir = Path(self._organizer.profile().absolutePath())
         except Exception:
@@ -184,7 +219,7 @@ class OpenMWGame(BasicGame):
         for raw in lo_file.read_text(encoding="utf-8", errors="replace").splitlines():
             line = raw.strip()
             if line and not line.startswith("#"):
-                out.append(line)
+                out.append(_destub_plugin_name(line))
         return out
 
     def _export_openmw_cfg(self, app_name: str) -> bool:
@@ -243,7 +278,7 @@ class OpenMWGame(BasicGame):
                     # entry shows up in MO2's plugin list. The real file is scanned
                     # separately; loading the empty stub as content= is at best useless
                     # and at worst aborts OpenMW ("sub-record incomplete").
-                    if low.endswith((".omwaddon.esp", ".omwscripts.esp", ".omwgame.esp")):
+                    if low.endswith(_KEZYMA_STUB_SUFFIXES):
                         continue
                     ext = f.suffix.lower()
                     if ext in {".esm", ".omwgame"}:

--- a/libs/basic_games/games/game_openmw.py
+++ b/libs/basic_games/games/game_openmw.py
@@ -171,6 +171,22 @@ class OpenMWGame(BasicGame):
                 out.append(line)
         return out
 
+    def _read_loadorder_txt(self) -> list[str]:
+        """Plugin load order from <profile>/loadorder.txt (MO2 right-pane order)."""
+        try:
+            profile_dir = Path(self._organizer.profile().absolutePath())
+        except Exception:
+            return []
+        lo_file = profile_dir / "loadorder.txt"
+        if not lo_file.is_file():
+            return []
+        out: list[str] = []
+        for raw in lo_file.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = raw.strip()
+            if line and not line.startswith("#"):
+                out.append(line)
+        return out
+
     def _export_openmw_cfg(self, app_name: str) -> bool:
         # onAboutToRun fires for every launched program; only act for OpenMW.
         if not self._is_openmw_binary(app_name):
@@ -203,8 +219,10 @@ class OpenMWGame(BasicGame):
             # source of truth. Tiers follow OpenMW convention: masters
             # (.esm/.omwgame) before plugins (.esp/.omwaddon), and .omwscripts
             # (Lua manifests, no records) last. Within a tier we keep mod-priority
-            # order (and alphabetical within a single mod). The user refines the
-            # final load order in OpenMW's own launcher.
+            # order (and alphabetical within a single mod). The tier order is the
+            # fallback; when <profile>/loadorder.txt exists it is the authoritative
+            # order and we stable-sort by it (unranked OpenMW-native plugins stay
+            # after the ranked ones, keeping their tier order).
             masters: list[str] = []         # .esm / .omwgame
             normal_plugins: list[str] = []  # .esp / .omwaddon
             omw_scripts: list[str] = []     # .omwscripts
@@ -267,6 +285,15 @@ class OpenMWGame(BasicGame):
             # re-shipping a vanilla esm (or two mods sharing a plugin name) won't
             # produce duplicate content= lines.
             all_plugins = masters + normal_plugins + omw_scripts
+            loadorder = self._read_loadorder_txt()
+            if loadorder:
+                rank = {name.lower(): i for i, name in enumerate(loadorder)}
+                # Stable sort: ranked plugins by loadorder.txt position, unranked
+                # (.omwaddon/.omwscripts/.omwgame not in MO2's list) keep their
+                # current order after all ranked ones.
+                all_plugins.sort(
+                    key=lambda p: rank.get(p.lower(), len(rank))
+                )
             plugin_lower = {p.lower() for p in all_plugins}
 
             groundcover = self._read_groundcover_txt()


### PR DESCRIPTION
## Order OpenMW `content=` by `loadorder.txt`

### Problem

`game_openmw.py` writes the OpenMW `content=` load order by scanning each active
mod's directory in MO2 **left-pane mod-priority** order (`allModsByProfilePriority`),
then concatenating with rigid tiering (`masters + normal_plugins + omw_scripts`).

In OpenMW, later `content=` entries override earlier ones, so the order is the
plugin load order — not the mod priority. MO2's authoritative plugin load order
lives in `<profile>/loadorder.txt` (the right pane). The generated `content=`
order therefore did not match the user's intended load order, producing wrong
record-override resolution (broken quests, missing overrides, …). On a 1500-mod
list this is impractical to fix by hand in `openmw-launcher`, which the old code
comment expected the user to do.

### Fix

Add `_read_loadorder_txt()` (mirroring the existing `_read_groundcover_txt()`)
that reads `<profile>/loadorder.txt`, then stable-sort the assembled
`content=` list by the rank read from it.

- Plugins present in `loadorder.txt` are ordered exactly as it specifies.
- Plugins **not** in `loadorder.txt` — `.omwaddon` / `.omwscripts` / `.omwgame`
  files MO2 doesn't track, plus Kezyma stub ESPs that `_scan_mod` already
  filters — keep their current tier order (`masters → plugins → scripts`) and
  are placed **after** all ranked plugins. This works because Python's
  `list.sort()` is stable and all unranked plugins get the same fallback key
  (`len(rank)`).
- Case-insensitive matching handles mixed-case extensions (`.esp` / `.ESP`).
- `str.splitlines()` handles MO2's CRLF line endings correctly.
- The first `# This file was automatically generated by Mod Organizer.` comment
  line and any blank lines are skipped.
- If `loadorder.txt` is missing, behavior falls back to the previous tiering +
  mod-priority order — **no regression**.

### What did **not** change

- `openmw_cfg.py` is untouched — the writer already accepts an ordered
  `content_plugins` list and writes it as-is.
- `lockedorder.txt` is **not** read; `loadorder.txt` already reflects the final
  order including locks.
- The tiering logic in `_scan_mod` is kept as the fallback order for unranked
  plugins.
- `build_managed_block`'s vanilla-master prepend/dedup in `openmw_cfg.py:108`
  still works: `Morrowind.esm` / `Tribunal.esm` / `Bloodmoon.esm` are prepended
  and deduped case-insensitively; since `loadorder.txt` lists them first, there
  is no conflict.

### Changes

`libs/basic_games/games/game_openmw.py` (+29, −2)

1. New method `_read_loadorder_txt()` after `_read_groundcover_txt()`.
2. After building `all_plugins = masters + normal_plugins + omw_scripts`, sort
   by `loadorder.txt` rank.
3. Updated the stale comment that claimed "The user refines the final load order
   in OpenMW's own launcher".

```diff
+            all_plugins = masters + normal_plugins + omw_scripts
+            loadorder = self._read_loadorder_txt()
+            if loadorder:
+                rank = {name.lower(): i for i, name in enumerate(loadorder)}
+                # Stable sort: ranked plugins by loadorder.txt position, unranked
+                # (.omwaddon/.omwscripts/.omwgame not in MO2's list) keep their
+                # current order after all ranked ones.
+                all_plugins.sort(
+                    key=lambda p: rank.get(p.lower(), len(rank))
+                )
             plugin_lower = {p.lower() for p in all_plugins}
```

### Testing

- [ ] Profile with `loadorder.txt`: `content=` order matches `loadorder.txt`
      exactly (except vanilla masters prepended, and `.omwaddon` / `.omwscripts`
      appended at the end).
- [ ] Profile with **no** `loadorder.txt`: falls back to current behavior
      (tiering + mod priority order) — no regression.
- [ ] CRLF line endings in `loadorder.txt` parse correctly.
- [ ] Mixed-case extensions (`.esp` / `.ESP`) match case-insensitively.
