### PR TITLE
Fall back to openmw.cfg groundcover= when groundcover.txt is absent

### DIFF
--- a/libs/basic_games/games/game_openmw.py
+++ b/libs/basic_games/games/game_openmw.py
@@ -156,19 +156,45 @@ class OpenMWGame(BasicGame):
         return base in {"openmw", "openmw-launcher", "flatpak"}
 
     def _read_groundcover_txt(self) -> list[str]:
-        """Plugins the user has flagged as groundcover, from <profile>/groundcover.txt."""
+        """Plugins flagged as groundcover, from <profile>/groundcover.txt,
+        falling back to groundcover= entries in <profile>/openmw.cfg (Kezyma's
+        OpenMW Player output) when groundcover.txt is absent."""
         try:
             profile_dir = Path(self._organizer.profile().absolutePath())
         except Exception:
             return []
+
+        # Primary source: Fluorine-native groundcover.txt (user-controlled).
+        # Takes precedence over Kezyma's list so a user who creates this file
+        # stays in control of what loads as groundcover.
         gc_file = profile_dir / "groundcover.txt"
-        if not gc_file.is_file():
+        if gc_file.is_file():
+            out: list[str] = []
+            for raw in gc_file.read_text(encoding="utf-8", errors="replace").splitlines():
+                line = raw.strip().lstrip("*").strip()
+                if line and not line.startswith("#"):
+                    out.append(line)
+            return out
+
+        # Fallback: groundcover= entries in the profile's openmw.cfg. Kezyma's
+        # OpenMW Player writes these directly (Wabbajack modlists like NEMAS
+        # ship them instead of a groundcover.txt), so parsing them here makes
+        # Fluorine route grass mods to groundcover= out-of-the-box. We split on
+        # the first '=' (not startswith) so 'groundcover = X' with spaces around
+        # '=' is handled the same as 'groundcover=X'.
+        profile_cfg = profile_dir / "openmw.cfg"
+        if not profile_cfg.is_file():
             return []
-        out: list[str] = []
-        for raw in gc_file.read_text(encoding="utf-8", errors="replace").splitlines():
-            line = raw.strip().lstrip("*").strip()
-            if line and not line.startswith("#"):
-                out.append(line)
+        out = []
+        for raw in profile_cfg.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            if key.strip().lower() == "groundcover":
+                value = value.strip()
+                if value:
+                    out.append(value)
         return out
 
     def _export_openmw_cfg(self, app_name: str) -> bool:


### PR DESCRIPTION
# Fall back to `openmw.cfg` `groundcover=` when `groundcover.txt` is absent

## Summary

`_read_groundcover_txt()` now falls back to parsing `groundcover=` entries from
the profile's `openmw.cfg` (Kezyma's OpenMW Player output) when a
`groundcover.txt` doesn't exist. This makes Fluorine route grass mods to
`groundcover=` out-of-the-box for Wabbajack modlists built for Kezyma's plugin
(such as Nerevar Moon-and-Star / NEMAS, which ships 22 `groundcover=` lines),
instead of loading them as expensive `content=` entries.

Closes #<issue number>

## Background

`libs/basic_games/games/game_openmw.py` routes grass/groundcover plugins to
`groundcover=` lines in `openmw.cfg` for better performance (loaded through
OpenMW's dedicated groundcover path rather than as full `content=` plugins).
The groundcover plugin list comes from `<profile>/groundcover.txt` via
`_read_groundcover_txt()`.

The problem: modlists built for Kezyma's OpenMW Player do **not** ship a
`groundcover.txt`. Instead, Kezyma's plugin writes `groundcover=` entries
directly into the profile's `openmw.cfg` (`<profile>/openmw.cfg`). For NEMAS,
this file contains 22 `groundcover=` lines (e.g. `groundcover=Grass AI.esp`,
`groundcover=groundcover.omwaddon`, etc.).

Since Fluorine only looked for `groundcover.txt`, these 22 grass plugins fell
back to `content=` — they still loaded (not dropped) but as expensive `content=`
entries instead of the optimized `groundcover=` path, a notable FPS hit for 22
grass mods.

## Change

Modified `_read_groundcover_txt()` to add a fallback with this precedence:

1. `<profile>/groundcover.txt` (Fluorine-native, user-controlled) — highest
   priority, takes precedence if it exists.
2. `groundcover=` entries in `<profile>/openmw.cfg` (Kezyma's output) —
   fallback.
3. Empty list (previous behavior) — if neither source exists.

This preserves user control: if a user creates `groundcover.txt`, it overrides
Kezyma's list. If they don't, Kezyma's list is used automatically — zero manual
setup.

### Implementation notes

- The profile's `openmw.cfg` (Kezyma's source, read here) is distinct from the
  engine config that `write_openmw_cfg()` writes to (`~/.config/openmw/openmw.cfg`
  or the Flatpak equivalent), so there is no circular read/write conflict.
- Parsing uses `line.partition("=")` rather than `line.startswith("groundcover=")`
  so mixed spacing around `=` (e.g. `groundcover = Plugin.esp`) is handled the
  same as `groundcover=Plugin.esp`.
- Blank-value `groundcover=` lines and `#`-commented lines are skipped.

### What was *not* changed

- `_export_openmw_cfg()` is untouched — the groundcover list from
  `_read_groundcover_txt()` is already consumed correctly (routed to
  `groundcover=`, removed from `content=`, validated against active mods).
- `openmw_cfg.py` is untouched — the writer already handles the groundcover list.
- The existing non-destructive "nudge" that logs a hint for grass-named plugins
  the user hasn't listed still never reroutes automatically.

## Verification

No formal test suite exists for `game_openmw.py`; verified manually with a
self-contained Python harness that replicates the parsing branches (no
mobase/Qt needed) and exercises the scenarios below. All pass.

- [x] Profile with `groundcover.txt`: uses `groundcover.txt` exclusively;
      fallback **not** triggered.
- [x] Profile with no `groundcover.txt` but `openmw.cfg` containing
      `groundcover=` entries: parses and returns those entries.
- [x] Profile with neither: returns `[]` (no regression vs. previous behavior).
- [x] `openmw.cfg` with mixed spacing around `=` (`groundcover = X`,
      `groundcover=X`, `groundcover  =  X`): all handled uniformly.
- [x] `groundcover.txt` present alongside `openmw.cfg`: `groundcover.txt` wins.
- [x] Blank-value (`groundcover=`, `groundcover=   `) and `#`-commented
      `groundcover=` lines: ignored.
- [x] `game_openmw.py` parses cleanly (`ast.parse`).
- [ ] End-to-end: verify the 22 NEMAS groundcover plugins route to `groundcover=`
      and are removed from `content=` in the generated `~/.config/openmw/openmw.cfg`.
      *(Requires a live NEMAS profile; left for the reviewer/maintainer.)*

## Risk

Low. The change is additive and confined to one method. The only behavioral
change for existing users is: profiles that previously had no `groundcover.txt`
but did have `groundcover=` lines in their profile `openmw.cfg` will now route
those plugins to `groundcover=` instead of `content=` — which is the intended
optimization and matches what Kezyma's toolchain already expects. Users with a
`groundcover.txt` see no change at all.
