### PR TITLE
Fix plugin_data PermissionError on read-only base dirs

### DIFF
--- a/src/src/organizercore.cpp
+++ b/src/src/organizercore.cpp
@@ -59,6 +59,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QFutureWatcher>
+#include <QStandardPaths>
 #include <QMessageBox>
 #include <QNetworkInterface>
 #include <QPointer>
@@ -1320,10 +1321,25 @@ void OrganizerCore::setPersistent(const QString& pluginName, const QString& key,
 
 QString OrganizerCore::pluginDataPath()
 {
-  // The plugins/ directory may contain symlinks into a read-only bundled
-  // directory (e.g. /app/ in Flatpak). Place plugin data in a separate
-  // writable directory so mkdir() never hits a read-only filesystem.
-  return AppConfig::basePath() + "/plugin_data";
+  // Place plugin data in a writable directory so plugin mkdir() calls never
+  // hit a read-only filesystem. Prefer the install-relative plugin_data/ dir
+  // (portable installs, or any install whose base dir is user-writable);
+  // fall back to a user-writable location when the base dir is read-only
+  // (e.g. a system-wide /opt install, or a Flatpak /app with read-only base).
+  const QString basePath  = AppConfig::basePath();
+  const QString candidate = basePath + "/plugin_data";
+
+  // Use the install-relative dir when it is already writable, or when its
+  // parent (basePath) is writable so the plugin can create it on demand.
+  if (QFileInfo(candidate).isWritable() || QFileInfo(basePath).isWritable()) {
+    return candidate;
+  }
+
+  // Base dir is not writable — redirect to a user-writable location, keeping
+  // plugin data alongside Fluorine's other runtime data
+  // (~/.local/share/fluorine/plugin_data).
+  return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+         + "/fluorine/plugin_data";
 }
 
 MOBase::IModInterface* OrganizerCore::installMod(const QString& archivePath,


### PR DESCRIPTION
# Make `pluginDataPath()` writable-aware for system-wide installs

## Summary

`IOrganizer::pluginDataPath()` returns a path under the install base directory
(`basePath()/plugin_data`). When Fluorine is installed system-wide under a
root-owned location such as `/opt/fluorine-manager`, this directory is not
writable by the user, and any plugin that calls `os.makedirs()` on
`pluginDataPath()/<plugin>` crashes at startup with `PermissionError: [Errno 13]
Permission denied`.

This PR makes `pluginDataPath()` fall back to a user-writable location
(`~/.local/share/fluorine/plugin_data`) when the install-relative directory is
not writable, while preserving the existing behavior for portable installs.

## Problem

A plugin that needs a private data folder reaches it through
`organizer.pluginDataPath()`, which is implemented as:

```cpp
// src/src/organizercore.cpp
QString OrganizerCore::pluginDataPath()
{
  return AppConfig::basePath() + "/plugin_data";
}
```

`AppConfig::basePath()` resolves to `MO2_BASE_DIR` when set (the
`/usr/bin/fluorine-manager` wrapper exports it as the install root, e.g.
`/opt/fluorine-manager`), otherwise to the binary's directory. For a
system-wide `/opt` install both the base dir and its `plugin_data` subdirectory
are `root:root 755`, so a regular user cannot create subdirectories there.

The failure is non-fatal to the application (the exception is caught by the
plugin proxy and the plugin is skipped), but it aborts the plugin's
`initialSetup()` before it can finish, leaving the plugin in a half-initialized
state. Concrete reproduction: Kezyma's OpenMW Player, bundled with the Nerevar
Moon-and-Star (NEMAS) Wabbajack modlist, throws during UI initialization:

```
an error occurred: PermissionError: [Errno 13] Permission denied: '/opt/fluorine-manager/plugin_data/OpenMWPlayer'
At:
  <frozen os>(230): makedirs
  .../openmwplayer.py(36): initialSetup
  .../openmwplayer_launcher.py(58): _onUiInit
  .../openmwplayer_launcher.py(27): <lambda>
```

The existing code comment at this site already states the intent — *"Place
plugin data in a separate writable directory so mkdir() never hits a read-only
filesystem"* — but the implementation never actually enforced writability; it
just appended `/plugin_data` to a base dir that may itself be read-only.

## Fix

Make `pluginDataPath()` writable-aware:

```cpp
QString OrganizerCore::pluginDataPath()
{
  const QString basePath  = AppConfig::basePath();
  const QString candidate = basePath + "/plugin_data";

  // Use the install-relative dir when it is already writable, or when its
  // parent (basePath) is writable so the plugin can create it on demand.
  if (QFileInfo(candidate).isWritable() || QFileInfo(basePath).isWritable()) {
    return candidate;
  }

  // Base dir is not writable — redirect to a user-writable location, keeping
  // plugin data alongside Fluorine's other runtime data
  // (~/.local/share/fluorine/plugin_data).
  return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
         + "/fluorine/plugin_data";
}
```

`QFileInfo::isWritable()` is used for the writability probe:

- When the `plugin_data` directory already exists and is writable, it is used
  as before.
- When it does not exist yet but its parent (`basePath`) is writable, the
  install-relative path is still returned so the plugin can create the
  directory on demand (matches the previous behavior for portable installs).
- Only when neither condition holds (read-only base dir) does the path redirect
  to `QStandardPaths::GenericDataLocation` + `/fluorine/plugin_data`, which
  resolves to `~/.local/share/fluorine/plugin_data` on Linux.

The fallback location reuses Fluorine's existing runtime-data convention:
the NXM listener socket already lives at
`~/.local/share/fluorine/tmp/mo2-nxm.sock` (`src/src/nxmhandler_linux.cpp`), so
no new convention is introduced. The function is `static`, so the choice is
made once per process and cached implicitly by the single call in
`MOApplication::setup()` (`setPluginDataPath(OrganizerCore::pluginDataPath())`).

## Behavior matrix

| Install layout | `basePath` writable? | `plugin_data` exists+writable? | Returned path |
|---|---|---|---|
| Portable in `$HOME` | yes | no (created later) | `<base>/plugin_data` (unchanged) |
| Portable in `$HOME` | yes | yes | `<base>/plugin_data` (unchanged) |
| System-wide `/opt` | no | no | `~/.local/share/fluorine/plugin_data` (new) |
| Flatpak `/app` (read-only base) | no | no | `~/.local/share/fluorine/plugin_data` (new) |

Portable installs are byte-for-byte unchanged: the second `isWritable()` branch
(parent-writable) covers the common case where `plugin_data` has not been
created yet, which is exactly the previous behavior.

## Why this approach

`pluginDataPath()` is the single choke point every plugin reaches for its data
directory — the Python proxy's `sys.path` setup (`libs/plugin_python/src/proxy/
proxypython.cpp`) and `OrganizerProxy::pluginDataPath()`
(`src/src/organizerproxy.cpp`) both forward to `OrganizerCore::pluginDataPath()`.
Patching it once fixes every plugin (current and future) without per-plugin
workarounds, environment variables, or wrapper scripts.

Alternatives considered and rejected:

- **Per-plugin patches**: redirect each plugin's path resolution. Fragile,
  re-applied on every plugin update, and doesn't help plugins not yet shipped.
- **A custom launch wrapper exporting `MO2_BASE_DIR` to a user dir**: works, but
  requires users to maintain a wrapper, keep `MO2_LIBS_DIR`/`MO2_PLUGINS_DIR`
  in sync, and lose the fix whenever launching via the desktop entry or the
  stock `/usr/bin/fluorine-manager` wrapper (which resets `MO2_BASE_DIR`).
- **`chown` the install-relative `plugin_data` dir**: requires root, must be
  re-applied after every package upgrade, and weakens the read-only guarantee
  of a system install.

The redirect chosen here is no-op for portable installs, needs no root, and
survives package upgrades because it lives in the application binary rather
than the filesystem.

## Scope and compatibility

- **No CMake change** — `<QStandardPaths>` is part of Qt6 Core, already linked.
- **No behavior change for portable installs** — verified by the second
  `isWritable()` branch above.
- **Python plugins** see the redirected path through the existing
  `IOrganizer::pluginDataPath()` binding; no binding change required.
- The `Configurator` deprecation/init warnings seen in the same logs are a
  separate, non-blocking issue and are not addressed by this PR.

## Testing

- **Portable install** (base dir in `$HOME`, writable): confirm
  `pluginDataPath()` still returns `<base>/plugin_data` and a plugin can
  `makedirs()` it. Expected: identical to pre-patch behavior.
- **System-wide `/opt` install** (base dir `root:root 755`): launch Fluorine
  with a plugin that calls `os.makedirs(organizer.pluginDataPath() + "/X")`.
  Expected: directory is created under `~/.local/share/fluorine/plugin_data/X`
  instead of raising `PermissionError`; the plugin's `initialSetup()` completes.
  Reproducer: Kezyma's OpenMW Player on the NEMAS modlist no longer throws the
  `PermissionError` from `openmwplayer.py:initialSetup`.
- **Read-only `plugin_data` that already exists** (e.g. root-owned): confirm
  the probe fails and the user-writable fallback is used.
- **Fresh first run** (no `plugin_data` anywhere): for a portable install, the
  install-relative path is still returned and created on demand; for a system
  install, the user-writable dir is created on demand.

## Changes

`src/src/organizercore.cpp`:
- Add `#include <QStandardPaths>`.
- `OrganizerCore::pluginDataPath()`: probe writability of the install-relative
  `plugin_data` (and its parent `basePath`) before returning it; fall back to
  `QStandardPaths::GenericDataLocation` + `/fluorine/plugin_data` when the base
  dir is not writable.
