### PR TITLE
Fix appVersion returning Version instead of VersionInfo in Python binding

### DIFF
--- a/libs/plugin_python/src/mobase/wrappers/basic_classes.cpp
+++ b/libs/plugin_python/src/mobase/wrappers/basic_classes.cpp
@@ -583,7 +583,10 @@ namespace mo2::python {
                      mo2::python::show_deprecation_warning(
                          "appVersion", "IOrganizer::appVersion() is deprecated, use "
                                        "IOrganizer::version() instead.");
-                     return o.version();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+                     return o.appVersion();
+#pragma GCC diagnostic pop
                  })
             .def("version", &IOrganizer::version)
             .def("createMod", &IOrganizer::createMod,


### PR DESCRIPTION
# Fix `appVersion()` returning `Version` instead of `VersionInfo` in Python binding

## Summary

The Python binding for the deprecated `IOrganizer::appVersion()` calls
`o.version()` directly, returning the new immutable `mobase.Version` type
instead of the legacy `mobase.VersionInfo` that the method historically
returned. This breaks backward compatibility for any plugin that compares
`appVersion()` against a `VersionInfo` literal: `Version` only supports
comparison with another `Version`, so the `>=` operator raises
`TypeError: '>=' not supported between instances of 'mobase.Version' and
'mobase.VersionInfo'`.

This PR fixes the binding to call `o.appVersion()` — the existing C++
backward-compatibility shim on `OrganizerProxy` that converts `Version` back to
`VersionInfo` — restoring the return type contract of the deprecated method.

## Problem

`IOrganizer` declares two version accessors (`libs/uibase/include/uibase/
imoinfo.h`):

```cpp
[[deprecated]] virtual VersionInfo appVersion() const = 0;   // line 139
virtual Version version() const = 0;                        // line 144
```

The new `Version` class (`libs/uibase/include/uibase/versioning.h`) is an
immutable SemVer type. The legacy `VersionInfo` class
(`libs/uibase/include/uibase/versioninfo.h`) is the older mutable type that
plugins historically received from `appVersion()`. The two are separate types
with no implicit cross-conversion.

The Python binding for the deprecated `appVersion` was wired to call the
**new** `version()` instead of the deprecated `appVersion()`
(`libs/plugin_python/src/mobase/wrappers/basic_classes.cpp`):

```cpp
.def("appVersion",
     [](IOrganizer& o) {
         mo2::python::show_deprecation_warning(
             "appVersion", "IOrganizer::appVersion() is deprecated, use "
                           "IOrganizer::version() instead.");
         return o.version();          // ← returns Version, not VersionInfo
     })
```

A plugin that builds its comparison threshold as a `VersionInfo` and compares
against `appVersion()` — a pattern that was correct before the `Version`/
`VersionInfo` split — now hits a `TypeError` because `mobase.Version` only
defines `py::self >= py::self` (line 128) with no cross-type comparison to
`mobase.VersionInfo`.

### Concrete reproducer

Kezyma's OpenMW Player (bundled with the Nerevar Moon-and-Star Wabbajack
modlist) crashes during UI initialization:

```python
# openmwplayer_launcher.py:76-78
minContentVer = mobase.VersionInfo("2.5.3")
moVersion = self._organiser.appVersion()   # now returns mobase.Version
if moVersion >= minContentVer:              # Version >= VersionInfo -> TypeError
```

```
an error occurred: TypeError: '>=' not supported between instances of 'mobase.Version' and 'mobase.VersionInfo'
At:
  .../openmwplayer_launcher.py(78): _registerGameFeatures
  .../openmwplayer_launcher.py(57): _onUiInit
  .../openmwplayer_launcher.py(27): <lambda>
```

The crash is non-fatal to the application (the plugin proxy catches it and
the plugin is skipped), but it aborts the plugin's UI-initialization handler
before it can finish, leaving the plugin in a half-initialized state.

## Root cause

The binding lambda bypasses an **existing** C++ backward-compatibility shim:

1. Python plugins receive an `OrganizerProxy` as their `IOrganizer&`
   (`src/src/plugincontainer.cpp:477` — `new OrganizerProxy(m_Organizer, this,
   plugin)`). `OrganizerCore` itself does not implement `IOrganizer`
   (`src/src/organizercore.h:65` — it inherits `QObject, IPluginDiagnose`).

2. `OrganizerProxy::appVersion()` (`src/src/organizerproxy.cpp:133`) already
   does the correct thing: it calls `m_Proxied->version()` and converts the
   `Version` back into a `VersionInfo` (extracting major/minor/patch and
   mapping `Version::ReleaseType` → `VersionInfo::ReleaseType`). This is the
   shim the deprecated method is *supposed* to be.

3. The binding lambda calls `o.version()` instead of `o.appVersion()`, so the
   shim is never invoked and the return type silently changed from
   `VersionInfo` to `Version` — breaking the deprecation contract.

Both `VersionInfo` (string constructor at `basic_classes.cpp:163`, all six
comparisons at lines 184-189) and `Version` (comparisons at lines 128-130)
are fully bound in Python, so the types are comparable within their own kind —
the failure is purely the cross-type mismatch caused by the lambda returning the
wrong one.

## Fix

Call `o.appVersion()` instead of `o.version()` so the existing
`OrganizerProxy::appVersion()` shim performs the `Version` → `VersionInfo`
conversion:

```cpp
.def("appVersion",
     [](IOrganizer& o) {
         mo2::python::show_deprecation_warning(
             "appVersion", "IOrganizer::appVersion() is deprecated, use "
                           "IOrganizer::version() instead.");
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         return o.appVersion();
#pragma GCC diagnostic pop
     })
```

The `#pragma GCC diagnostic` suppression is needed because `appVersion()` is
`[[deprecated]]` in the C++ header (`imoinfo.h:139`); without it, compiling
this binding emits a `-Wdeprecated-declarations` warning at the call site.
The pragma is honored by both GCC and Clang (Fluorine is Linux-only) and has
precedent in the tree (`libs/archive/thirdparty/CPP/Common/Common0.h:118`).

The Python-side deprecation warning (`show_deprecation_warning(...)`) is
**kept**: it still nudges plugin authors to migrate to `version()`, exactly as
before. The fix only restores the *return type* of the deprecated method, not
its deprecation status.

## Why this approach

This is the minimal change at the single binding site that restores the
historical return-type contract of a deprecated method, using an existing C++
shim that was written precisely for this purpose.

Alternatives considered and rejected:

- **Per-plugin patches** (e.g. changing `mobase.VersionInfo("2.5.3")` to
  `mobase.Version.parse("2.5.3")` in each affected plugin): masks the symptom
  in third-party files, must be re-applied whenever a plugin is re-extracted,
  and doesn't help plugins not yet audited. The root cause — a deprecated
  method silently changing its return type — remains.
- **Adding cross-type comparison operators** (`Version` vs `VersionInfo`) to
  the Python bindings: widens the API surface, introduces an implicit semantic
  mapping between two versioning schemes (they have different release-type
  enums and parsing rules), and papers over the real bug rather than fixing it.
- **Removing `appVersion()` from the binding entirely**: would break every
  plugin still calling it (the whole point of a *deprecated* method is to keep
  working).

## Scope and compatibility

- **No behavior change for `version()`** — the non-deprecated accessor is
  untouched and continues to return `mobase.Version`.
- **`appVersion()` now returns `mobase.VersionInfo` again**, matching its
  pre-split behavior. Plugins comparing `appVersion()` against `VersionInfo`
  literals (the historically-correct pattern) work without modification.
- **Deprecation warning preserved** — the Python-side
  `show_deprecation_warning` still fires on every `appVersion()` call.
- **`canonicalString()`** — the `canonicalString` compatibility shim already
  added to `Version` in the binding (`basic_classes.cpp:117-126`) remains
  harmless for `version().canonicalString()` callers; with this fix,
  `appVersion().canonicalString()` also resolves to the real
  `VersionInfo::canonicalString()` (`basic_classes.cpp:175`).

## Testing

- Build with `./build.sh` — confirm no `-Wdeprecated-declarations` warning at
  the binding site (the pragma suppresses it).
- Launch with a plugin that calls `self._organiser.appVersion()` and compares
  the result against `mobase.VersionInfo("2.5.3")` using `>=`. Expected: the
  comparison evaluates without `TypeError`. Reproducer: Kezyma's OpenMW Player
  on the NEMAS modlist no longer throws the `TypeError` from
  `openmwplayer_launcher.py:_registerGameFeatures`.
- Confirm the Python-side deprecation warning is still emitted in the log
  (`[deprecated] appVersion ... IOrganizer::appVersion() is deprecated, use
  IOrganizer::version() instead.`) — this is desired behavior, not a
  regression.
- Confirm `version()` still returns `mobase.Version` and that
  `version() >= mobase.Version.parse("x.y.z")` works as before.

## Changes

`libs/plugin_python/src/mobase/wrappers/basic_classes.cpp`:
- `appVersion` binding lambda: call `o.appVersion()` instead of `o.version()`,
  wrapped in `#pragma GCC diagnostic` to suppress the C++
  `-Wdeprecated-declarations` warning at the call site. The Python-side
  deprecation warning is unchanged.
