### PR TITLE
ignore ctime/file permissions when hashing

### DIFF
--- a/src/src/vfs/vfscatalog.cpp
+++ b/src/src/vfs/vfscatalog.cpp
@@ -347,9 +347,7 @@ VfsTree VfsCatalog::reconcileAndBuild(
           reuseHash = sqlite3_column_int64(find.get(), 0) == st.st_dev &&
                       sqlite3_column_int64(find.get(), 1) == st.st_ino &&
                       sqlite3_column_int64(find.get(), 2) == st.st_size &&
-                      sqlite3_column_int64(find.get(), 3) == (st.st_mode & 07777) &&
                       sqlite3_column_int64(find.get(), 4) == mtimeNs &&
-                      sqlite3_column_int64(find.get(), 5) == ctimeNs &&
                       blob != nullptr && bytes == BLAKE3_OUT_LEN;
           if (reuseHash) std::memcpy(digest.data(), blob, digest.size());
         }


### PR DESCRIPTION
I noticed that the hashing check was being done every time I launched BG3 regardless of whether I made any changes to mod load order (or whether the game files updated, which is pretty infrequently). From some investigation, it seemed to be from an automatic recursive `chmod` happening from Fluorine after each run to ensure that Proton doesn't force things into readonly mode for silly reasons. Given that the hashing seems intended to avoid reloading stuff that hasn't changed, my instinct is that what we really care about is whether the contents of the file have changed rather than the file permissions/metadata, and that avoiding the extra hashing is itself a pretty useful optimization.

An alternative fix would be updating the chmod logic somehow (e.g. only running if something did actually change in permissions since last time), but that honestly seems even more likely to accidentally introduce a change that breaks things for people than the much smaller change to skip checking mode/ctime in the hashing, so I went with the simpler change.