### PR TITLE
Fix BG3 VFS

### DIFF
--- a/libs/basic_games/games/baldursgate3/bg3_file_mapper.py
+++ b/libs/basic_games/games/baldursgate3/bg3_file_mapper.py
@@ -138,18 +138,6 @@ class BG3FileMapper(mobase.IPluginFileMapper):
     def create_mapping(self, file: Path, dest: Path):
         bg3_utils.create_dir_if_needed(dest)
 
-        # On Linux, FUSE cannot handle file mappings outside the game's data
-        # directory.  Create real symlinks so the game (via Proton) can find
-        # mod files in the documents/prefix directory.
-        if _IS_LINUX and not file.is_dir():
-            try:
-                if dest.is_symlink() or dest.exists():
-                    dest.unlink()
-                dest.symlink_to(file)
-                self._linux_symlinks.append(dest)
-            except OSError as e:
-                qWarning(f"BG3: failed to symlink {dest} -> {file}: {e}")
-
         self.current_mappings.append(
             mobase.Mapping(
                 source=str(file),

--- a/libs/game_bethesda/src/games/starfield/gamestarfield.cpp
+++ b/libs/game_bethesda/src/games/starfield/gamestarfield.cpp
@@ -287,6 +287,14 @@ bool GameStarfield::prepareIni(const QString& exec)
   return true;  // no need to write to Starfield.ini
 }
 
+bool GameStarfield::needsAutoCreateDirectories() const
+{
+  // Starfield calls CreateFile("ShaderCache/Lighting/X.pso") without
+  // mkdir for intermediate directories.  The FUSE VFS must insert
+  // phantom directory entries so the kernel path resolver can continue.
+  return true;
+}
+
 QStringList GameStarfield::DLCPlugins() const
 {
   return {"Constellation.esm", "ShatteredSpace.esm", "SFBGS050.esm"};

--- a/libs/game_bethesda/src/games/starfield/gamestarfield.h
+++ b/libs/game_bethesda/src/games/starfield/gamestarfield.h
@@ -39,6 +39,7 @@ public:  // IPluginGame interface
   virtual QString gameNexusName() const override;
   virtual QStringList iniFiles() const override;
   virtual bool prepareIni(const QString& exec) override;
+  virtual bool needsAutoCreateDirectories() const override;
   virtual QStringList DLCPlugins() const override;
   virtual QStringList CCPlugins() const override;
   virtual QString blueprintPrefix() const override;

--- a/libs/plugin_python/src/mobase/wrappers/pyplugins.cpp
+++ b/libs/plugin_python/src/mobase/wrappers/pyplugins.cpp
@@ -54,6 +54,7 @@ namespace mo2::python {
             .def("isInstalled", &IPluginGame::isInstalled)
             .def("isNativeLinux", &IPluginGame::isNativeLinux)
             .def("usesVFS", &IPluginGame::usesVFS)
+            .def("needsAutoCreateDirectories", &IPluginGame::needsAutoCreateDirectories)
             .def("gameIcon", &IPluginGame::gameIcon)
             .def("gameDirectory", &IPluginGame::gameDirectory)
             .def("dataDirectory", &IPluginGame::dataDirectory)

--- a/libs/plugin_python/src/mobase/wrappers/pyplugins.h
+++ b/libs/plugin_python/src/mobase/wrappers/pyplugins.h
@@ -438,6 +438,10 @@ namespace mo2::python {
         {
             PYBIND11_OVERRIDE(bool, IPluginGame, usesVFS, );
         }
+        bool needsAutoCreateDirectories() const override
+        {
+            PYBIND11_OVERRIDE(bool, IPluginGame, needsAutoCreateDirectories, );
+        }
         QIcon gameIcon() const override
         {
             PYBIND11_OVERRIDE_PURE(QIcon, IPluginGame, gameIcon, );

--- a/libs/uibase/include/uibase/iplugingame.h
+++ b/libs/uibase/include/uibase/iplugingame.h
@@ -167,6 +167,18 @@ public:
   /**
    * this function may be called before init()
    *
+   * @return true if the FUSE VFS should auto-create intermediate directories
+   *         when a lookup misses (needed by Starfield, which skips mkdir for
+   *         parent directories and goes straight to CreateFile).  Most games
+   *         should leave this as false — creating phantom directories can
+   *         shadow real game files that are resolved through normal VFS
+   *         traversal.
+   */
+  virtual bool needsAutoCreateDirectories() const { return false; }
+
+  /**
+   * this function may be called before init()
+   *
    * @return an icon for this game
    */
   virtual QIcon gameIcon() const = 0;

--- a/src/src/fuseconnector.cpp
+++ b/src/src/fuseconnector.cpp
@@ -664,6 +664,7 @@ bool FuseConnector::mount(
   m_context->gid                   = ::getgid();
   m_context->cache_disabled        = m_disableVfsCache ||
                                      std::getenv("FLUORINE_VFS_DISABLE_CACHE") != nullptr;
+  m_context->auto_create_dirs      = m_autoCreateDirs;
   const auto indexStart = std::chrono::steady_clock::now();
   const std::size_t prewarmed = mo2PrewarmLookupIndex(m_context.get());
   const auto indexMs = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -914,6 +915,13 @@ void FuseConnector::updateMapping(const MappingType& mapping)
     throw FuseConnectorException(QObject::tr("Managed game not available"));
   }
 
+  // Propagate the game's auto-create-dirs preference to the VFS context.
+  // Starfield sets this to true; most other games (e.g. BG3) leave it false.
+  m_autoCreateDirs = game->needsAutoCreateDirectories();
+  if (m_context) {
+    m_context->auto_create_dirs = m_autoCreateDirs;
+  }
+
   const QString gameDir      = game->gameDirectory().absolutePath();
   const QString dataDirPath  = game->dataDirectory().absolutePath();
   const QString dataDirName  = game->dataDirectory().dirName();
@@ -1009,6 +1017,96 @@ void FuseConnector::deployExternalMappings(const MappingType& mapping,
   const QString cleanDataDir = QDir::cleanPath(dataDir);
   const QString dataPrefix   = cleanDataDir + QStringLiteral("/");
 
+  // Helper: create a directory (and all missing parents) and record each
+  // segment we actually created so cleanup can remove it later.
+  std::error_code ec;
+  auto createTrackedDirs = [&](const fs::path& dirPath) {
+    std::vector<fs::path> toCreate;
+    for (fs::path p = dirPath; !p.empty() && !fs::exists(p, ec);
+         p = p.parent_path()) {
+      toCreate.push_back(p);
+      if (p == p.root_path()) {
+        break;
+      }
+    }
+    // Build top-down so nested dirs succeed.
+    for (auto it = toCreate.rbegin(); it != toCreate.rend(); ++it) {
+      if (fs::create_directory(*it, ec) && !ec) {
+        m_externalDirs.push_back(it->string());
+      }
+    }
+  };
+
+  // --- Pass 1: createTarget directory mappings must be processed first ---
+  // If a per-file mapping (e.g. a mod .pak) creates entries in the
+  // destination before the directory symlink is established, the
+  // directory symlink check sees real content and falls back to
+  // per-file symlinks.  Processing the directory mapping first avoids
+  // this: the symlink is created while the destination is still empty,
+  // then file mappings create their symlinks through the directory
+  // symlink into the overwrite directory.
+  for (const auto& map : mapping) {
+    const QString src =
+        QDir::cleanPath(QDir::fromNativeSeparators(map.source));
+    const QString dst =
+        QDir::cleanPath(QDir::fromNativeSeparators(map.destination));
+
+    const bool targetsDataDir =
+        (dst == cleanDataDir || dst.startsWith(dataPrefix));
+
+    if (targetsDataDir) {
+      continue;
+    }
+
+    if (!map.isDirectory || !map.createTarget) {
+      continue;
+    }
+
+    const fs::path srcPath(src.toStdString());
+    const fs::path dstPath(dst.toStdString());
+
+    if (!fs::exists(srcPath, ec)) {
+      fs::create_directories(srcPath, ec);
+      if (ec) {
+        ec.clear();
+      }
+    }
+    const bool dstExists  = fs::exists(dstPath, ec);
+    ec.clear();
+    const bool dstIsLink  = dstExists && fs::is_symlink(dstPath, ec);
+    ec.clear();
+    const bool dstIsEmpty = dstExists && fs::is_directory(dstPath, ec) &&
+                            fs::is_empty(dstPath, ec);
+    ec.clear();
+
+    if (!dstExists || dstIsLink || dstIsEmpty) {
+      createTrackedDirs(dstPath.parent_path());
+      if (dstIsLink) {
+        fs::remove(dstPath, ec);
+        ec.clear();
+      } else if (dstIsEmpty) {
+        fs::remove(dstPath, ec);
+        ec.clear();
+      }
+      fs::create_directory_symlink(srcPath, dstPath, ec);
+      if (!ec) {
+        m_externalSymlinks.push_back(dstPath.string());
+        log::debug("Deployed directory symlink {} -> {}", dst, src);
+        continue;
+      }
+      log::warn("Failed to symlink directory {} -> {}: {}", dst, src,
+                QString::fromStdString(ec.message()));
+      ec.clear();
+    } else {
+      log::warn(
+          "Mapped folder {} contains real files; falling back to per-file "
+          "symlinks. Move existing contents into {} and restart to fully "
+          "redirect new writes.",
+          dst, src);
+    }
+  }
+
+  // --- Pass 2: everything else (file mappings, non-createTarget dirs) ---
   for (const auto& map : mapping) {
     const QString src =
         QDir::cleanPath(QDir::fromNativeSeparators(map.source));
@@ -1032,89 +1130,17 @@ void FuseConnector::deployExternalMappings(const MappingType& mapping,
       continue;
     }
 
-    // Non-data-dir mapping — deploy via real symlinks so the game
-    // (running through Proton) can see the files.
-    std::error_code ec;
-
-    // Helper: create a directory (and all missing parents) and record each
-    // segment we actually created so cleanup can remove it later.
-    auto createTrackedDirs = [&](const fs::path& dirPath) {
-      std::vector<fs::path> toCreate;
-      for (fs::path p = dirPath; !p.empty() && !fs::exists(p, ec);
-           p = p.parent_path()) {
-        toCreate.push_back(p);
-        if (p == p.root_path()) {
-          break;
-        }
-      }
-      // Build top-down so nested dirs succeed.
-      for (auto it = toCreate.rbegin(); it != toCreate.rend(); ++it) {
-        if (fs::create_directory(*it, ec) && !ec) {
-          m_externalDirs.push_back(it->string());
-        }
-      }
-    };
+    // Skip createTarget directory mappings — already handled in pass 1.
+    if (map.isDirectory && map.createTarget) {
+      continue;
+    }
 
     if (map.isDirectory) {
       const fs::path srcPath(src.toStdString());
       const fs::path dstPath(dst.toStdString());
 
-      // For createTarget directory mappings (e.g. SKSE Log Redirector
-      // pointing My Games/Skyrim → Skyrim Special Edition), publish a single
-      // directory symlink so any new file the game writes under the dest
-      // path is also redirected — not just the files that exist in source
-      // at deploy time. Falls back to per-file symlinks when the dest dir
-      // already contains real content we mustn't clobber.
-      if (map.createTarget) {
-        if (!fs::exists(srcPath, ec)) {
-          fs::create_directories(srcPath, ec);
-          if (ec) {
-            ec.clear();
-          }
-        }
-        const bool dstExists  = fs::exists(dstPath, ec);
-        ec.clear();
-        const bool dstIsLink  = dstExists && fs::is_symlink(dstPath, ec);
-        ec.clear();
-        const bool dstIsEmpty = dstExists && fs::is_directory(dstPath, ec) &&
-                                fs::is_empty(dstPath, ec);
-        ec.clear();
-
-        if (!dstExists || dstIsLink || dstIsEmpty) {
-          createTrackedDirs(dstPath.parent_path());
-          if (dstIsLink) {
-            fs::remove(dstPath, ec);
-            ec.clear();
-          } else if (dstIsEmpty) {
-            fs::remove(dstPath, ec);
-            ec.clear();
-          }
-          fs::create_directory_symlink(srcPath, dstPath, ec);
-          if (!ec) {
-            m_externalSymlinks.push_back(dstPath.string());
-            log::debug("Deployed directory symlink {} -> {}", dst, src);
-            continue;
-          }
-          log::warn("Failed to symlink directory {} -> {}: {}", dst, src,
-                    QString::fromStdString(ec.message()));
-          ec.clear();
-        } else {
-          log::warn(
-              "Mapped folder {} contains real files; falling back to per-file "
-              "symlinks. Move existing contents into {} and restart to fully "
-              "redirect new writes.",
-              dst, src);
-        }
-      }
-
       if (!fs::exists(srcPath, ec)) {
         continue;
-      }
-
-      if (map.createTarget) {
-        // Pre-create the dst root so an empty source still leaves it tracked
-        // for removal on cleanup.
-        createTrackedDirs(dstPath);
       }
 
       for (auto it = fs::recursive_directory_iterator(

--- a/src/src/fuseconnector.h
+++ b/src/src/fuseconnector.h
@@ -51,6 +51,10 @@ public:
   // vfs/mo2filesystem.h for what this actually toggles.
   void setDisableVfsCache(bool disabled) { m_disableVfsCache = disabled; }
 
+  // When true, the FUSE VFS inserts phantom directories for missing path
+  // components (needed by Starfield).  Must be set before the next mount().
+  void setAutoCreateDirs(bool enabled) { m_autoCreateDirs = enabled; }
+
   void unmount();
   void discardStagingOnUnmount();
   bool isMounted() const;
@@ -114,6 +118,7 @@ private:
   bool m_mounted        = false;
   bool m_discardStaging = false;
   bool m_disableVfsCache = false;
+  bool m_autoCreateDirs = false;
 
   // Gives logind an accurate reason for suspend/shutdown/lock prompts while
   // mounted, instead of the generic "systemd (1)". See sleepinhibitor.h.

--- a/src/src/vfs/mo2filesystem.cpp
+++ b/src/src/vfs/mo2filesystem.cpp
@@ -1627,8 +1627,11 @@ void mo2_lookup(fuse_req_t req, fuse_ino_t parent, const char* name)
     // call mo2_create. Insert a phantom virtual directory — no physical creation.
     // createFile() calls create_directories on the parent path, so the real dir
     // will materialize on disk only when a file is actually written inside it.
+    // Gated behind auto_create_dirs: most games (e.g. BG3) must not have
+    // phantom directories injected because they shadow real entries resolved
+    // through normal VFS traversal.
     const std::string_view nameView(name);
-    if (nameView.find('.') == std::string_view::npos) {
+    if (ctx->auto_create_dirs && nameView.find('.') == std::string_view::npos) {
       bool parentOk = false;
       const std::string parentPath = inodeToPath(ctx, parent, &parentOk);
       if (parentOk) {

--- a/src/src/vfs/mo2filesystem.h
+++ b/src/src/vfs/mo2filesystem.h
@@ -186,6 +186,12 @@ struct Mo2FsContext
   // Not meant to stay on by default — see the June 2026 shader-cache/INI-
   // clobber fix for why keep_cache=1 exists normally.
   bool cache_disabled = false;
+
+  // When true, mo2_lookup inserts phantom directories for missing path
+  // components that look like directories (no dot).  Needed by Starfield
+  // which calls CreateFile on paths whose parents haven't been mkdir'd.
+  // Most games must leave this false to avoid shadowing real entries.
+  bool auto_create_dirs = false;
 };
 
 // Eagerly materialize the persistent catalog's resolved tree as runtime inode


### PR DESCRIPTION
On the `main` branch currently, BG3 fails to start up properly for me due to a number of game files not loading properly. I traced back the issue to the "phantom" directory creation for Starfield (and maybe other games?) getting in the way of the ability to map BG3 game files properly. However, removing it outright would presumably break Starfield, so instead I added it as an optional check that games can enable in their plugins.

I don't own Starfield, so unfortunately I don't have a way to test that the logic is working properly. I did verify that BG3 launches for me properly again with this branch, but it's properly safer not to merge it until someone can test that it works for Starfield. I'm also not sure if it would make more sense to keep the extra phantom directory step as "opt-in" as this branch does or if it should be the default with plugins for games like BG3 opting out of it; that seems like a judgment call about whether the behavior is more expected than unexpected and how many games will be broken by it versus broken without it, and I don't have any strong instincts in that regard.