### PR TITLE
Do not update associations in obsolete path

### DIFF
--- a/docker/build-inner.sh
+++ b/docker/build-inner.sh
@@ -626,6 +626,9 @@ if [ -f "${DESKTOP_SRC}" ]; then
         "${DESKTOP_SRC}" > "${DESKTOP_TMP}"; then
         chmod +x "${DESKTOP_TMP}"
         mv -f "${DESKTOP_TMP}" "${DESKTOP_DST}"
+        command -v update-desktop-database >/dev/null 2>&1 && \
+            update-desktop-database "$(dirname "${DESKTOP_DST}")" \
+                >/dev/null 2>&1 || true
     else
         rm -f "${DESKTOP_TMP}"
     fi
@@ -807,7 +810,9 @@ StartupWMClass=ModOrganizer
 DESKTOP_EOF
         chmod +x "${DESKTOP_DIR}/com.fluorine.manager.desktop"
 
-
+        # Update desktop database if available
+        command -v update-desktop-database >/dev/null 2>&1 && \
+            update-desktop-database "${DESKTOP_DIR}" 2>/dev/null || true
         echo ""
         echo "Installation complete!"
         echo "  Binary:   ${INSTALL_DIR}/fluorine-manager"

--- a/docker/build-inner.sh
+++ b/docker/build-inner.sh
@@ -626,9 +626,6 @@ if [ -f "${DESKTOP_SRC}" ]; then
         "${DESKTOP_SRC}" > "${DESKTOP_TMP}"; then
         chmod +x "${DESKTOP_TMP}"
         mv -f "${DESKTOP_TMP}" "${DESKTOP_DST}"
-        command -v update-desktop-database >/dev/null 2>&1 && \
-            update-desktop-database "$(dirname "${DESKTOP_DST}")" \
-                >/dev/null 2>&1 || true
     else
         rm -f "${DESKTOP_TMP}"
     fi
@@ -810,9 +807,6 @@ StartupWMClass=ModOrganizer
 DESKTOP_EOF
         chmod +x "${DESKTOP_DIR}/com.fluorine.manager.desktop"
 
-        # Update desktop database if available
-        command -v update-desktop-database >/dev/null 2>&1 && \
-            update-desktop-database "${DESKTOP_DIR}" 2>/dev/null || true
 
         echo ""
         echo "Installation complete!"

--- a/src/src/nxmhandler_linux.cpp
+++ b/src/src/nxmhandler_linux.cpp
@@ -243,23 +243,6 @@ void runDesktopCommand(const QString& program, const QStringList& arguments)
   }
 }
 
-void setDefaultAssociation(const QString& mimeType, const QString& desktopFile)
-{
-  runDesktopCommand(QStringLiteral("xdg-mime"),
-                    QStringList{QStringLiteral("default"), desktopFile, mimeType});
-
-  // Some GLib/GNOME stacks cache associations independently of direct
-  // mimeapps.list edits. gio is optional, so absence is only logged at debug.
-  runDesktopCommand(QStringLiteral("gio"),
-                    QStringList{QStringLiteral("mime"), mimeType, desktopFile});
-}
-
-void refreshDesktopAssociationCaches(const QString& appsDir)
-{
-  runDesktopCommand(QStringLiteral("update-desktop-database"), QStringList{appsDir});
-  runDesktopCommand(QStringLiteral("xdg-desktop-menu"),
-                    QStringList{QStringLiteral("forceupdate")});
-}
 
 // xdg-desktop-portal remembers chooser picks in its permission store. An
 // earlier build registered both com.fluorine.manager.desktop and
@@ -517,11 +500,7 @@ void NxmHandlerLinux::registerHandler()
 
   for (const auto& scheme : UrlSchemes) {
     updateMimeAppsList(configDir + "/mimeapps.list", scheme, NxmDesktopFile);
-    updateMimeAppsList(appsDir + "/mimeapps.list", scheme, NxmDesktopFile);
-    setDefaultAssociation(scheme, NxmDesktopFile);
   }
-
-  refreshDesktopAssociationCaches(appsDir);
 
   for (const auto& scheme : UrlSchemes) {
     clearStalePortalChoice(scheme);
@@ -546,13 +525,10 @@ void NxmHandlerLinux::unregisterHandler()
 
   for (const auto& scheme : UrlSchemes) {
     removeMimeAppsAssociation(configDir + "/mimeapps.list", scheme, NxmDesktopFile);
-    removeMimeAppsAssociation(appsDir + "/mimeapps.list", scheme, NxmDesktopFile);
   }
 
   QFile::remove(appsDir + "/" + NxmDesktopFile);
   QFile::remove(appsDir + "/" + LegacyNxmDesktopFile);
-
-  refreshDesktopAssociationCaches(appsDir);
 
   for (const auto& scheme : UrlSchemes) {
     clearStalePortalChoice(scheme);

--- a/src/src/nxmhandler_linux.cpp
+++ b/src/src/nxmhandler_linux.cpp
@@ -243,6 +243,45 @@ void runDesktopCommand(const QString& program, const QStringList& arguments)
   }
 }
 
+void refreshDesktopAssociationCaches(const QString& appsDir)
+{
+  runDesktopCommand(QStringLiteral("update-desktop-database"), QStringList{appsDir});
+  runDesktopCommand(QStringLiteral("xdg-desktop-menu"),
+                    QStringList{QStringLiteral("forceupdate")});
+}
+
+// Older releases also wrote user preferences beside the desktop files. That
+// mimeapps.list location is deprecated, but clean up our entries when the file
+// already exists so upgrading users are not left with conflicting defaults.
+// Never create the deprecated file as part of cleanup.
+void cleanLegacyMimeAppsList(const QString& path)
+{
+  if (!QFileInfo::exists(path)) {
+    return;
+  }
+
+  QStringList lines = readMimeAppsList(path);
+  const QStringList sections = {
+      QStringLiteral("[Default Applications]"),
+      QStringLiteral("[Added Associations]"),
+      QStringLiteral("[Removed Associations]"),
+  };
+
+  for (const auto& scheme : UrlSchemes) {
+    for (const auto& section : sections) {
+      updateMimeSection(
+          lines, section, scheme,
+          [](QStringList desktopFiles) {
+            removeDesktopFile(desktopFiles, NxmDesktopFile);
+            removeDesktopFile(desktopFiles, LegacyNxmDesktopFile);
+            return desktopFiles;
+          },
+          false);
+    }
+  }
+
+  writeTextFile(path, lines.join('\n') + "\n");
+}
 
 // xdg-desktop-portal remembers chooser picks in its permission store. An
 // earlier build registered both com.fluorine.manager.desktop and
@@ -498,9 +537,13 @@ void NxmHandlerLinux::registerHandler()
 
   QFile::remove(appsDir + "/" + LegacyNxmDesktopFile);
 
+  cleanLegacyMimeAppsList(appsDir + "/mimeapps.list");
+
   for (const auto& scheme : UrlSchemes) {
     updateMimeAppsList(configDir + "/mimeapps.list", scheme, NxmDesktopFile);
   }
+
+  refreshDesktopAssociationCaches(appsDir);
 
   for (const auto& scheme : UrlSchemes) {
     clearStalePortalChoice(scheme);
@@ -527,8 +570,12 @@ void NxmHandlerLinux::unregisterHandler()
     removeMimeAppsAssociation(configDir + "/mimeapps.list", scheme, NxmDesktopFile);
   }
 
+  cleanLegacyMimeAppsList(appsDir + "/mimeapps.list");
+
   QFile::remove(appsDir + "/" + NxmDesktopFile);
   QFile::remove(appsDir + "/" + LegacyNxmDesktopFile);
+
+  refreshDesktopAssociationCaches(appsDir);
 
   for (const auto& scheme : UrlSchemes) {
     clearStalePortalChoice(scheme);


### PR DESCRIPTION
Right now Fluorine Manager create next 2 files upon its start:
- `~/.local/share/applications/mimeinfo.cache`
- `~/.local/share/applications/mimeapps.list`

`~/.local/share/applications` is a [deprecated](https://wiki.archlinux.org/title/XDG_MIME_Applications#mimeapps.list) location for `mimeapps.list` and `mimeinfo.cache` and on KDE Plasma these files are creating with wrong associations and override proper files located in `~/.config` which breaks desktop experience. This MR prevents Fluorine from creating these two files under `~/.local/share/applications`