### PR TITLE
Fix Heroic Epic namespace detection

### DIFF
--- a/libs/basic_games/epic_utils.py
+++ b/libs/basic_games/epic_utils.py
@@ -7,6 +7,7 @@ import os
 import sys
 from collections.abc import Iterable
 from pathlib import Path
+from typing import cast
 
 try:
     import winreg
@@ -70,8 +71,103 @@ def find_legendary_games(
         try:
             with open(installed_path, encoding="utf-8") as installed_file:
                 installed_games = json.load(installed_file)
+            primary_app_names: set[str] = set()
+            namespace_paths: dict[str, set[Path]] = {}
+            game_namespace_paths: dict[str, set[Path]] = {}
+            presence_namespace_paths: dict[str, set[Path]] = {}
             for game in installed_games.values():
-                yield game["app_name"], Path(game["install_path"])
+                app_name = game["app_name"]
+                install_path = Path(game["install_path"])
+                yield app_name, install_path
+
+                # Plugins normally use Epic's namespace as GameEpicId, while
+                # Legendary records installed games by their launch app name.
+                # They are often identical, but games such as Cyberpunk 2077
+                # use different values (77f2... and "Ginger", respectively).
+                if not isinstance(app_name, str):
+                    continue
+                primary_app_names.add(app_name)
+                if game.get("is_dlc"):
+                    continue
+                if Path(app_name).name != app_name:
+                    continue
+
+                metadata_path = legendary_config_path / "metadata" / f"{app_name}.json"
+                if not metadata_path.is_file():
+                    continue
+
+                try:
+                    with open(metadata_path, encoding="utf-8") as metadata_file:
+                        game_metadata = json.load(metadata_file)
+
+                    namespaces: set[str] = set()
+                    is_game = False
+                    presence_id: str | None = None
+                    asset_infos: object = game_metadata.get("asset_infos")
+                    if isinstance(asset_infos, dict):
+                        for asset_info in cast(
+                            dict[object, object], asset_infos
+                        ).values():
+                            if isinstance(asset_info, dict):
+                                namespace = cast(dict[object, object], asset_info).get(
+                                    "namespace"
+                                )
+                                if isinstance(namespace, str) and namespace:
+                                    namespaces.add(namespace)
+
+                    metadata: object = game_metadata.get("metadata")
+                    if isinstance(metadata, dict):
+                        metadata_dict = cast(dict[object, object], metadata)
+                        namespace = metadata_dict.get("namespace")
+                        if isinstance(namespace, str) and namespace:
+                            namespaces.add(namespace)
+                        categories = metadata_dict.get("categories")
+                        if isinstance(categories, list):
+                            is_game = any(
+                                isinstance(category, dict)
+                                and cast(dict[object, object], category).get("path")
+                                == "games"
+                                for category in cast(list[object], categories)
+                            )
+                        custom_attributes = metadata_dict.get("customAttributes")
+                        if isinstance(custom_attributes, dict):
+                            presence = cast(
+                                dict[object, object], custom_attributes
+                            ).get("PresenceId")
+                            if isinstance(presence, dict):
+                                value = cast(dict[object, object], presence).get(
+                                    "value"
+                                )
+                                if isinstance(value, str) and value:
+                                    presence_id = value
+
+                    for namespace in namespaces:
+                        namespace_paths.setdefault(namespace, set()).add(install_path)
+                        if is_game:
+                            game_namespace_paths.setdefault(namespace, set()).add(
+                                install_path
+                            )
+                        if presence_id == namespace:
+                            presence_namespace_paths.setdefault(namespace, set()).add(
+                                install_path
+                            )
+                except (json.JSONDecodeError, AttributeError, OSError):
+                    # The app-name mapping is still valid when optional cached
+                    # metadata is missing or stale.
+                    pass
+
+            for namespace, install_paths in namespace_paths.items():
+                # Never let a derived alias replace Legendary's authoritative
+                # app-name mapping. PresenceId identifies the canonical entry
+                # when extras share its namespace; the game category and unique
+                # path remain fallbacks for metadata without that attribute.
+                candidate_paths = presence_namespace_paths.get(
+                    namespace,
+                    game_namespace_paths.get(namespace, install_paths),
+                )
+                if namespace in primary_app_names or len(candidate_paths) != 1:
+                    continue
+                yield namespace, next(iter(candidate_paths))
         except (json.JSONDecodeError, AttributeError, KeyError) as e:
             error_message = (
                 f'Unable to parse installed games from Legendary/Heroic launcher: "{installed_path}"\n'

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(SQLite3 REQUIRED)
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 # ---------------------------------------------------------------------------
-# OpenMW native config generation tests
+# Python regression tests
 # ---------------------------------------------------------------------------
 add_test(
     NAME test_openmw_cfg
@@ -15,6 +15,10 @@ add_test(
 add_test(
     NAME test_flatpak_access
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_flatpak_access.py
+)
+add_test(
+    NAME test_epic_utils
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_epic_utils.py
 )
 
 # ---------------------------------------------------------------------------

--- a/src/tests/test_epic_utils.py
+++ b/src/tests/test_epic_utils.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+MODULE_PATH = Path(__file__).parents[2] / "libs" / "basic_games" / "epic_utils.py"
+SPEC = importlib.util.spec_from_file_location("epic_utils", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load {MODULE_PATH}")
+epic_utils = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(epic_utils)
+
+
+def write_game(
+    config_path: Path,
+    app_name: str,
+    install_path: Path,
+    namespace: str | None = None,
+    is_dlc: bool = False,
+    is_game: bool = True,
+    has_presence_id: bool = False,
+) -> None:
+    legendary_path = config_path / "legendary"
+    metadata_path = legendary_path / "metadata"
+    metadata_path.mkdir(parents=True, exist_ok=True)
+
+    installed_path = legendary_path / "installed.json"
+    installed: dict[str, object] = (
+        json.loads(installed_path.read_text(encoding="utf-8"))
+        if installed_path.is_file()
+        else {}
+    )
+    installed[app_name] = {
+        "app_name": app_name,
+        "install_path": str(install_path),
+        "is_dlc": is_dlc,
+    }
+    installed_path.write_text(json.dumps(installed), encoding="utf-8")
+
+    if namespace is not None:
+        (metadata_path / f"{app_name}.json").write_text(
+            json.dumps(
+                {
+                    "asset_infos": {"Windows": {"namespace": namespace}},
+                    "metadata": {
+                        "namespace": namespace,
+                        "categories": [
+                            {"path": "games" if is_game else "digitalextras"}
+                        ],
+                        "customAttributes": (
+                            {"PresenceId": {"value": namespace}}
+                            if has_presence_id
+                            else {}
+                        ),
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+
+class FindLegendaryGamesTest(unittest.TestCase):
+    def test_indexes_epic_namespace_from_heroic_metadata(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            config_path = Path(temporary_directory)
+            install_path = Path("/games/Cyberpunk2077")
+            write_game(
+                config_path,
+                "Ginger",
+                install_path,
+                namespace="77f2b98e2cef40c8a7437518bf420e47",
+            )
+
+            games = dict(epic_utils.find_legendary_games(str(config_path)))
+
+            self.assertEqual(games["Ginger"], install_path)
+            self.assertEqual(games["77f2b98e2cef40c8a7437518bf420e47"], install_path)
+
+    def test_keeps_app_name_mapping_when_metadata_is_invalid(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            config_path = Path(temporary_directory)
+            install_path = Path("/games/example")
+            write_game(config_path, "Example", install_path)
+            metadata_path = config_path / "legendary" / "metadata" / "Example.json"
+            metadata_path.write_text("{", encoding="utf-8")
+
+            games = dict(epic_utils.find_legendary_games(str(config_path)))
+
+            self.assertEqual(games, {"Example": install_path})
+
+    def test_does_not_index_dlc_namespace(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            config_path = Path(temporary_directory)
+            install_path = Path("/games/example-dlc")
+            write_game(
+                config_path,
+                "ExampleDLC",
+                install_path,
+                namespace="example-namespace",
+                is_dlc=True,
+            )
+
+            games = dict(epic_utils.find_legendary_games(str(config_path)))
+
+            self.assertEqual(games, {"ExampleDLC": install_path})
+
+    def test_namespace_does_not_override_primary_app_name(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            config_path = Path(temporary_directory)
+            primary_path = Path("/games/primary")
+            write_game(config_path, "Primary", primary_path)
+            write_game(
+                config_path,
+                "Other",
+                Path("/games/other"),
+                namespace="Primary",
+            )
+
+            games = dict(epic_utils.find_legendary_games(str(config_path)))
+
+            self.assertEqual(games["Primary"], primary_path)
+
+    def test_prefers_presence_id_with_shared_namespace(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            config_path = Path(temporary_directory)
+            game_path = Path("/games/main")
+            write_game(
+                config_path,
+                "MainGame",
+                game_path,
+                namespace="shared-namespace",
+                has_presence_id=True,
+            )
+            write_game(
+                config_path,
+                "BonusContent",
+                Path("/games/bonus"),
+                namespace="shared-namespace",
+            )
+
+            games = dict(epic_utils.find_legendary_games(str(config_path)))
+
+            self.assertEqual(games["shared-namespace"], game_path)
+
+    def test_skips_namespace_with_multiple_install_paths(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            config_path = Path(temporary_directory)
+            write_game(
+                config_path,
+                "First",
+                Path("/games/first"),
+                namespace="shared-namespace",
+            )
+            write_game(
+                config_path,
+                "Second",
+                Path("/games/second"),
+                namespace="shared-namespace",
+            )
+
+            games = dict(epic_utils.find_legendary_games(str(config_path)))
+
+            self.assertNotIn("shared-namespace", games)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- index Heroic/Legendary Epic installs by both launch app name and Epic namespace
- ignore DLC entries when adding namespace aliases
- preserve authoritative app-name mappings and skip genuinely ambiguous aliases
- prefer Epic's `PresenceId` when bonus content shares the base game's namespace
- preserve app-name detection when optional cached metadata is missing or malformed
- add regression coverage for Heroic's Cyberpunk 2077 `Ginger`/`77f2...` mismatch

## Problem

`find_legendary_games()` currently reads only `app_name` from `installed.json`. Game plugins generally declare Epic's namespace as `GameEpicId`. These identifiers are often equal, but Heroic records Cyberpunk 2077 under the launch app name `Ginger` while its game plugin expects namespace `77f2b98e2cef40c8a7437518bf420e47`, so automatic detection fails.

Legendary's per-game metadata contains the namespace. This change adds it as an alias for the same install path while retaining the existing app-name entry.

Some separately installed extras share their base game's namespace. Alias selection therefore prefers a unique entry whose `PresenceId` matches that namespace, then a unique game-category entry, then a unique path. It does not overwrite primary app-name keys or guess between genuinely ambiguous paths.

## Validation

- 6 focused Heroic/Legendary discovery tests
- complete Python 3.12 regression suite: 37 passed
- Ruff 0.12.2 check and format check for changed files
- Pyright 1.1.402 strict check for changed files
- verified against a real Flatpak Heroic installation that the Cyberpunk namespace resolves to the installed game directory and executable
- compared live output with `main`: all 9 existing mappings preserved, 0 changed, 0 removed, and 6 namespace aliases added
- measured median discovery time at 0.269 ms versus 0.056 ms on `main`; a synthetic 1,000-install fixture completed in 12.4 ms
