### PR TITLE
Fix Heroic game and Proton discovery

### DIFF
--- a/libs/uibase/src/CMakeLists.txt
+++ b/libs/uibase/src/CMakeLists.txt
@@ -199,6 +199,7 @@ if(NOT WIN32)
 		PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/src>)
 	target_sources(uibase PRIVATE
 		${CMAKE_SOURCE_DIR}/src/src/gamedetection.cpp
+		${CMAKE_SOURCE_DIR}/src/src/heroicjson.cpp
 		${CMAKE_SOURCE_DIR}/src/src/steamdetection.cpp
 		${CMAKE_SOURCE_DIR}/src/src/vdfparser.cpp
 		${CMAKE_SOURCE_DIR}/src/src/iconextractor.cpp

--- a/src/src/CMakeLists.txt
+++ b/src/src/CMakeLists.txt
@@ -41,6 +41,7 @@ file(GLOB ORGANIZER_SOURCES
 # These files are compiled into libuibase.so (shared with plugins) — exclude from organizer.
 list(REMOVE_ITEM ORGANIZER_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/gamedetection.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/heroicjson.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/steamdetection.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vdfparser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/iconextractor.cpp

--- a/src/src/gamedetection.cpp
+++ b/src/src/gamedetection.cpp
@@ -1,4 +1,5 @@
 #include "gamedetection.h"
+#include "heroicjson.h"
 #include "knowngames.h"
 #include "vdfparser.h"
 
@@ -358,51 +359,67 @@ QVector<DetectedGame> detectHeroicGames()
 
     // --- Epic ---
     {
-      QString epicPath = heroicPath + "/store_cache/legendary_library.json";
-      if (!QFileInfo::exists(epicPath))
-        epicPath = heroicPath + "/legendaryConfig/legendary/installed.json";
+      // Parse both sources. The cache carries richer metadata but has changed
+      // shape over time; installed.json is authoritative for Legendary-native
+      // installs and normally omits is_installed.
+      static const char* EPIC_FILES[] = {
+          "/store_cache/legendary_library.json",
+          "/legendaryConfig/legendary/installed.json",
+      };
+      QSet<QString> seenAppNames;
 
-      QFile f(epicPath);
-      if (f.open(QIODevice::ReadOnly)) {
-        QJsonDocument const doc = QJsonDocument::fromJson(f.readAll());
-        if (doc.isObject()) {
-          const QJsonObject obj = doc.object();
-          for (auto it = obj.begin(); it != obj.end(); ++it) {
-            const QString appName = it.key();
-            const QJsonObject gd  = it.value().toObject();
+      for (const char* relativePath : EPIC_FILES) {
+        QFile f(heroicPath + QString::fromLatin1(relativePath));
+        if (!f.open(QIODevice::ReadOnly)) {
+          continue;
+        }
 
-            if (!gd[QStringLiteral("is_installed")].toBool())
-              continue;
-
-            const QString platform = gd[QStringLiteral("platform")].toString();
-            if (platform.toLower() != QStringLiteral("windows"))
-              continue;
-
-            const QString installPath = gd[QStringLiteral("install_path")].toString();
-            if (installPath.isEmpty() || !QFileInfo::exists(installPath))
-              continue;
-
-            const QString title = gd[QStringLiteral("title")].toString(appName);
-            const KnownGame* kg =
-                findKnownGameByEpicId(appName);
-            if (!kg)
-              kg = findKnownGameByTitle(title);
-
-            DetectedGame g;
-            g.name         = title;
-            g.app_id       = appName;
-            g.install_path = installPath;
-            g.prefix_path  = getHeroicGamePrefix(heroicPath, appName);
-            g.launcher     = QStringLiteral("Heroic (Epic)");
-            if (kg) {
-              g.my_games_folder        = kg->my_games_folder ? QString::fromLatin1(kg->my_games_folder) : QString();
-              g.appdata_local_folder   = kg->appdata_local_folder ? QString::fromLatin1(kg->appdata_local_folder) : QString();
-              g.appdata_roaming_folder = kg->appdata_roaming_folder ? QString::fromLatin1(kg->appdata_roaming_folder) : QString();
-              g.registry_path  = QString::fromLatin1(kg->registry_path);
-              g.registry_value = QString::fromLatin1(kg->registry_value);
-            }
-            games.append(g);
+        const QVector<HeroicEpicInstall> installs =
+            parseHeroicEpicInstalls(f.readAll());
+        for (const HeroicEpicInstall& install : installs) {
+          if (!install.is_installed ||
+              install.platform.compare(QStringLiteral("windows"),
+                                       Qt::CaseInsensitive) != 0 ||
+              install.install_path.isEmpty() ||
+              !QFileInfo::exists(install.install_path) ||
+              seenAppNames.contains(install.app_name)) {
+            continue;
           }
+
+          seenAppNames.insert(install.app_name);
+          const QString epicId = install.namespace_id.isEmpty()
+                                     ? install.app_name
+                                     : install.namespace_id;
+          const KnownGame* kg = findKnownGameByEpicId(epicId);
+          if (!kg && epicId != install.app_name) {
+            kg = findKnownGameByEpicId(install.app_name);
+          }
+          if (!kg) {
+            kg = findKnownGameByTitle(install.title);
+          }
+
+          DetectedGame g;
+          g.name         = install.title;
+          g.app_id       = install.app_name;
+          g.install_path = install.install_path;
+          g.prefix_path  = getHeroicGamePrefix(heroicPath, install.app_name);
+          g.launcher     = QStringLiteral("Heroic (Epic)");
+          if (kg) {
+            g.my_games_folder = kg->my_games_folder
+                                    ? QString::fromLatin1(kg->my_games_folder)
+                                    : QString();
+            g.appdata_local_folder =
+                kg->appdata_local_folder
+                    ? QString::fromLatin1(kg->appdata_local_folder)
+                    : QString();
+            g.appdata_roaming_folder =
+                kg->appdata_roaming_folder
+                    ? QString::fromLatin1(kg->appdata_roaming_folder)
+                    : QString();
+            g.registry_path  = QString::fromLatin1(kg->registry_path);
+            g.registry_value = QString::fromLatin1(kg->registry_value);
+          }
+          games.append(g);
         }
       }
     }

--- a/src/src/gamedetection.cpp
+++ b/src/src/gamedetection.cpp
@@ -377,7 +377,7 @@ QVector<DetectedGame> detectHeroicGames()
         const QVector<HeroicEpicInstall> installs =
             parseHeroicEpicInstalls(f.readAll());
         for (const HeroicEpicInstall& install : installs) {
-          if (!install.is_installed ||
+          if (!install.is_installed || install.is_dlc ||
               install.platform.compare(QStringLiteral("windows"),
                                        Qt::CaseInsensitive) != 0 ||
               install.install_path.isEmpty() ||

--- a/src/src/gamedetection.cpp
+++ b/src/src/gamedetection.cpp
@@ -359,68 +359,65 @@ QVector<DetectedGame> detectHeroicGames()
 
     // --- Epic ---
     {
-      // Parse both sources. The cache carries richer metadata but has changed
-      // shape over time; installed.json is authoritative for Legendary-native
-      // installs and normally omits is_installed.
-      static const char* EPIC_FILES[] = {
-          "/store_cache/legendary_library.json",
-          "/legendaryConfig/legendary/installed.json",
+      // installed.json is authoritative for installation state and paths;
+      // Heroic's cache enriches those entries with namespace and title data.
+      auto parseFile = [&](const QString& relativePath) {
+        QFile file(heroicPath + relativePath);
+        if (!file.open(QIODevice::ReadOnly)) {
+          return QVector<HeroicEpicInstall>{};
+        }
+        return parseHeroicEpicInstalls(file.readAll());
       };
-      QSet<QString> seenAppNames;
 
-      for (const char* relativePath : EPIC_FILES) {
-        QFile f(heroicPath + QString::fromLatin1(relativePath));
-        if (!f.open(QIODevice::ReadOnly)) {
+      const QVector<HeroicEpicInstall> installedManifest = parseFile(
+          QStringLiteral("/legendaryConfig/legendary/installed.json"));
+      const QVector<HeroicEpicInstall> libraryCache =
+          parseFile(QStringLiteral("/store_cache/legendary_library.json"));
+      const QVector<HeroicEpicInstall> installs =
+          mergeHeroicEpicInstalls(installedManifest, libraryCache);
+
+      for (const HeroicEpicInstall& install : installs) {
+        if (!install.is_installed || install.is_dlc ||
+            install.platform.compare(QStringLiteral("windows"),
+                                     Qt::CaseInsensitive) != 0 ||
+            install.install_path.isEmpty() ||
+            !QFileInfo::exists(install.install_path)) {
           continue;
         }
 
-        const QVector<HeroicEpicInstall> installs =
-            parseHeroicEpicInstalls(f.readAll());
-        for (const HeroicEpicInstall& install : installs) {
-          if (!install.is_installed || install.is_dlc ||
-              install.platform.compare(QStringLiteral("windows"),
-                                       Qt::CaseInsensitive) != 0 ||
-              install.install_path.isEmpty() ||
-              !QFileInfo::exists(install.install_path) ||
-              seenAppNames.contains(install.app_name)) {
-            continue;
-          }
-
-          seenAppNames.insert(install.app_name);
-          const QString epicId = install.namespace_id.isEmpty()
-                                     ? install.app_name
-                                     : install.namespace_id;
-          const KnownGame* kg = findKnownGameByEpicId(epicId);
-          if (!kg && epicId != install.app_name) {
-            kg = findKnownGameByEpicId(install.app_name);
-          }
-          if (!kg) {
-            kg = findKnownGameByTitle(install.title);
-          }
-
-          DetectedGame g;
-          g.name         = install.title;
-          g.app_id       = install.app_name;
-          g.install_path = install.install_path;
-          g.prefix_path  = getHeroicGamePrefix(heroicPath, install.app_name);
-          g.launcher     = QStringLiteral("Heroic (Epic)");
-          if (kg) {
-            g.my_games_folder = kg->my_games_folder
-                                    ? QString::fromLatin1(kg->my_games_folder)
-                                    : QString();
-            g.appdata_local_folder =
-                kg->appdata_local_folder
-                    ? QString::fromLatin1(kg->appdata_local_folder)
-                    : QString();
-            g.appdata_roaming_folder =
-                kg->appdata_roaming_folder
-                    ? QString::fromLatin1(kg->appdata_roaming_folder)
-                    : QString();
-            g.registry_path  = QString::fromLatin1(kg->registry_path);
-            g.registry_value = QString::fromLatin1(kg->registry_value);
-          }
-          games.append(g);
+        const QString epicId = install.namespace_id.isEmpty()
+                                   ? install.app_name
+                                   : install.namespace_id;
+        const KnownGame* kg = findKnownGameByEpicId(epicId);
+        if (!kg && epicId != install.app_name) {
+          kg = findKnownGameByEpicId(install.app_name);
         }
+        if (!kg) {
+          kg = findKnownGameByTitle(install.title);
+        }
+
+        DetectedGame g;
+        g.name         = install.title;
+        g.app_id       = install.app_name;
+        g.install_path = install.install_path;
+        g.prefix_path  = getHeroicGamePrefix(heroicPath, install.app_name);
+        g.launcher     = QStringLiteral("Heroic (Epic)");
+        if (kg) {
+          g.my_games_folder = kg->my_games_folder
+                                  ? QString::fromLatin1(kg->my_games_folder)
+                                  : QString();
+          g.appdata_local_folder =
+              kg->appdata_local_folder
+                  ? QString::fromLatin1(kg->appdata_local_folder)
+                  : QString();
+          g.appdata_roaming_folder =
+              kg->appdata_roaming_folder
+                  ? QString::fromLatin1(kg->appdata_roaming_folder)
+                  : QString();
+          g.registry_path  = QString::fromLatin1(kg->registry_path);
+          g.registry_value = QString::fromLatin1(kg->registry_value);
+        }
+        games.append(g);
       }
     }
   }

--- a/src/src/heroicjson.cpp
+++ b/src/src/heroicjson.cpp
@@ -4,6 +4,8 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QHash>
+#include <QSet>
 
 #include <utility>
 
@@ -24,9 +26,15 @@ HeroicEpicInstall parseInstall(const QJsonObject& game, const QString& fallbackA
   result.platform =
       install.value(QStringLiteral("platform"))
           .toString(game.value(QStringLiteral("platform")).toString());
-  result.is_installed = game.contains(QStringLiteral("is_installed"))
-                            ? game.value(QStringLiteral("is_installed")).toBool()
-                            : installedByPresence;
+  if (game.contains(QStringLiteral("is_installed"))) {
+    result.is_installed = game.value(QStringLiteral("is_installed")).toBool();
+  } else if (install.contains(QStringLiteral("is_installed"))) {
+    result.is_installed = install.value(QStringLiteral("is_installed")).toBool();
+  } else {
+    // Modern Heroic caches may omit is_installed. A populated nested install
+    // record is the remaining installation signal in that schema.
+    result.is_installed = installedByPresence || !result.install_path.isEmpty();
+  }
   result.is_dlc = install.contains(QStringLiteral("is_dlc"))
                       ? install.value(QStringLiteral("is_dlc")).toBool()
                       : game.value(QStringLiteral("is_dlc")).toBool();
@@ -75,4 +83,60 @@ QVector<HeroicEpicInstall> parseHeroicEpicInstalls(const QByteArray& json)
     }
   }
   return installs;
+}
+
+QVector<HeroicEpicInstall> mergeHeroicEpicInstalls(
+    const QVector<HeroicEpicInstall>& installedManifest,
+    const QVector<HeroicEpicInstall>& libraryCache)
+{
+  QVector<HeroicEpicInstall> result;
+  QHash<QString, qsizetype> indexes;
+  QSet<QString> manifestAppNames;
+
+  auto insertOrReplaceManifest = [&](const HeroicEpicInstall& install) {
+    const auto existing = indexes.constFind(install.app_name);
+    if (existing == indexes.constEnd()) {
+      indexes.insert(install.app_name, result.size());
+      result.append(install);
+    } else {
+      result[*existing] = install;
+    }
+    manifestAppNames.insert(install.app_name);
+  };
+
+  for (const HeroicEpicInstall& install : installedManifest) {
+    insertOrReplaceManifest(install);
+  }
+
+  for (const HeroicEpicInstall& cached : libraryCache) {
+    const auto existing = indexes.constFind(cached.app_name);
+    if (existing == indexes.constEnd()) {
+      indexes.insert(cached.app_name, result.size());
+      result.append(cached);
+      continue;
+    }
+
+    HeroicEpicInstall& merged = result[*existing];
+    if (!cached.namespace_id.isEmpty()) {
+      merged.namespace_id = cached.namespace_id;
+    }
+    if (!cached.title.isEmpty() && cached.title != cached.app_name) {
+      merged.title = cached.title;
+    }
+    if (merged.install_path.isEmpty()) {
+      merged.install_path = cached.install_path;
+    }
+    if (merged.platform.isEmpty()) {
+      merged.platform = cached.platform;
+    }
+    merged.is_dlc = merged.is_dlc || cached.is_dlc;
+
+    // Cache-only duplicate records may contribute installation state. When
+    // installed.json supplied the record, its state remains authoritative.
+    if (!manifestAppNames.contains(cached.app_name)) {
+      merged.is_installed = merged.is_installed || cached.is_installed;
+    }
+  }
+
+  return result;
 }

--- a/src/src/heroicjson.cpp
+++ b/src/src/heroicjson.cpp
@@ -27,6 +27,9 @@ HeroicEpicInstall parseInstall(const QJsonObject& game, const QString& fallbackA
   result.is_installed = game.contains(QStringLiteral("is_installed"))
                             ? game.value(QStringLiteral("is_installed")).toBool()
                             : installedByPresence;
+  result.is_dlc = install.contains(QStringLiteral("is_dlc"))
+                      ? install.value(QStringLiteral("is_dlc")).toBool()
+                      : game.value(QStringLiteral("is_dlc")).toBool();
   return result;
 }
 }  // namespace

--- a/src/src/heroicjson.cpp
+++ b/src/src/heroicjson.cpp
@@ -1,0 +1,75 @@
+#include "heroicjson.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+
+#include <utility>
+
+namespace
+{
+HeroicEpicInstall parseInstall(const QJsonObject& game, const QString& fallbackAppName,
+                               bool installedByPresence)
+{
+  const QJsonObject install = game.value(QStringLiteral("install")).toObject();
+
+  HeroicEpicInstall result;
+  result.app_name    = game.value(QStringLiteral("app_name")).toString(fallbackAppName);
+  result.namespace_id = game.value(QStringLiteral("namespace")).toString();
+  result.title       = game.value(QStringLiteral("title")).toString(result.app_name);
+  result.install_path =
+      install.value(QStringLiteral("install_path"))
+          .toString(game.value(QStringLiteral("install_path")).toString());
+  result.platform =
+      install.value(QStringLiteral("platform"))
+          .toString(game.value(QStringLiteral("platform")).toString());
+  result.is_installed = game.contains(QStringLiteral("is_installed"))
+                            ? game.value(QStringLiteral("is_installed")).toBool()
+                            : installedByPresence;
+  return result;
+}
+}  // namespace
+
+QVector<HeroicEpicInstall> parseHeroicEpicInstalls(const QByteArray& json)
+{
+  const QJsonDocument document = QJsonDocument::fromJson(json);
+  if (!document.isObject()) {
+    return {};
+  }
+
+  const QJsonObject root = document.object();
+  QVector<HeroicEpicInstall> installs;
+
+  // Current Heroic cache schema:
+  // {"library": [{"app_name": "...", "install": {...}}, ...]}
+  if (root.value(QStringLiteral("library")).isArray()) {
+    const QJsonArray library = root.value(QStringLiteral("library")).toArray();
+    installs.reserve(library.size());
+    for (const QJsonValue& value : library) {
+      if (!value.isObject()) {
+        continue;
+      }
+      HeroicEpicInstall install = parseInstall(value.toObject(), {}, false);
+      if (!install.app_name.isEmpty()) {
+        installs.append(std::move(install));
+      }
+    }
+    return installs;
+  }
+
+  // Legendary installed.json schema:
+  // {"AppName": {"app_name": "AppName", "install_path": "..."}, ...}
+  // Presence in this file means installed; it normally has no is_installed key.
+  installs.reserve(root.size());
+  for (auto it = root.constBegin(); it != root.constEnd(); ++it) {
+    if (!it.value().isObject()) {
+      continue;
+    }
+    HeroicEpicInstall install = parseInstall(it.value().toObject(), it.key(), true);
+    if (!install.app_name.isEmpty()) {
+      installs.append(std::move(install));
+    }
+  }
+  return installs;
+}

--- a/src/src/heroicjson.h
+++ b/src/src/heroicjson.h
@@ -1,0 +1,22 @@
+#ifndef HEROICJSON_H
+#define HEROICJSON_H
+
+#include <QByteArray>
+#include <QString>
+#include <QVector>
+
+struct HeroicEpicInstall
+{
+  QString app_name;
+  QString namespace_id;
+  QString title;
+  QString install_path;
+  QString platform;
+  bool is_installed = false;
+};
+
+/// Parse either Heroic's modern legendary_library.json cache or Legendary's
+/// installed.json into a common representation.
+QVector<HeroicEpicInstall> parseHeroicEpicInstalls(const QByteArray& json);
+
+#endif  // HEROICJSON_H

--- a/src/src/heroicjson.h
+++ b/src/src/heroicjson.h
@@ -20,4 +20,11 @@ struct HeroicEpicInstall
 /// installed.json into a common representation.
 QVector<HeroicEpicInstall> parseHeroicEpicInstalls(const QByteArray& json);
 
+/// Merge Legendary's authoritative installed manifest with Heroic's richer
+/// library cache. Manifest installation paths and state win; cache metadata
+/// fills namespace, title, and any missing fields.
+QVector<HeroicEpicInstall> mergeHeroicEpicInstalls(
+    const QVector<HeroicEpicInstall>& installedManifest,
+    const QVector<HeroicEpicInstall>& libraryCache);
+
 #endif  // HEROICJSON_H

--- a/src/src/heroicjson.h
+++ b/src/src/heroicjson.h
@@ -13,6 +13,7 @@ struct HeroicEpicInstall
   QString install_path;
   QString platform;
   bool is_installed = false;
+  bool is_dlc       = false;
 };
 
 /// Parse either Heroic's modern legendary_library.json cache or Legendary's

--- a/src/src/steamdetection.cpp
+++ b/src/src/steamdetection.cpp
@@ -189,13 +189,11 @@ void scanProtonDir(const QString& dir, bool isSteamBuiltin,
 
 }  // namespace
 
-QVector<SteamProtonInfo> findSteamProtons()
+QVector<SteamProtonInfo>
+findProtonsForPaths(const QStringList& steamLibraries,
+                    const QStringList& compatibilityToolDirs)
 {
   QVector<SteamProtonInfo> protons;
-
-  const QStringList steamLibraries = findSteamLibraryPaths();
-  if (steamLibraries.isEmpty())
-    return protons;
 
   // 1. Steam's built-in Protons across every Steam library. Steam may install
   // tools like "Proton 10.0" under a secondary library's steamapps/common.
@@ -216,8 +214,10 @@ QVector<SteamProtonInfo> findSteamProtons()
                   false, protons);
   }
 
-  // 3. System-level Protons.
-  scanProtonDir(QStringLiteral("/usr/share/steam/compatibilitytools.d"), false, protons);
+  // 3. Other supported compatibility-tool directories (system and Heroic).
+  for (const QString& directory : compatibilityToolDirs) {
+    scanProtonDir(directory, false, protons);
+  }
 
   // Filter to Proton 10+.
   protons.erase(
@@ -277,4 +277,19 @@ QVector<SteamProtonInfo> findSteamProtons()
             });
 
   return protons;
+}
+
+QVector<SteamProtonInfo> findSteamProtons()
+{
+  const QString home = QDir::homePath();
+  const QStringList compatibilityToolDirs = {
+      QStringLiteral("/usr/share/steam/compatibilitytools.d"),
+      QDir(home).filePath(QStringLiteral(".config/heroic/tools/proton")),
+      QDir(home).filePath(QStringLiteral(
+          ".var/app/com.heroicgameslauncher.hgl/config/heroic/tools/proton")),
+  };
+
+  // Do not require Steam to be installed: Heroic and system Proton runners
+  // are valid inputs for Fluorine's direct Proton launcher.
+  return findProtonsForPaths(findSteamLibraryPaths(), compatibilityToolDirs);
 }

--- a/src/src/steamdetection.h
+++ b/src/src/steamdetection.h
@@ -29,7 +29,14 @@ __attribute__((visibility("default"))) QString findSteamPath();
 /// Find all Steam library root paths, including secondary libraries.
 __attribute__((visibility("default"))) QStringList findSteamLibraryPaths();
 
-/// Find all installed Proton versions (Proton 10+ only, sorted newest first).
+/// Find supported Proton versions in explicit Steam libraries and additional
+/// compatibility-tool directories. Exposed separately for deterministic tests.
+__attribute__((visibility("default"))) QVector<SteamProtonInfo>
+findProtonsForPaths(const QStringList& steamLibraries,
+                    const QStringList& compatibilityToolDirs);
+
+/// Find all installed Proton versions, including Steam, system, and Heroic
+/// installations (Proton 10+ only, sorted newest first).
 __attribute__((visibility("default"))) QVector<SteamProtonInfo> findSteamProtons();
 
 #endif // STEAMDETECTION_H

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -80,6 +80,50 @@ target_link_libraries(test_metainiutils PRIVATE
 add_test(NAME test_metainiutils COMMAND test_metainiutils)
 
 # ---------------------------------------------------------------------------
+# Heroic/Legendary JSON schema normalization tests
+# ---------------------------------------------------------------------------
+add_executable(test_heroicjson EXCLUDE_FROM_ALL
+    test_heroicjson.cpp
+    ${CMAKE_SOURCE_DIR}/src/src/heroicjson.cpp
+)
+set_target_properties(test_heroicjson PROPERTIES
+    AUTOMOC OFF
+    CXX_STANDARD 23
+    CXX_STANDARD_REQUIRED ON
+)
+target_include_directories(test_heroicjson PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/src
+)
+target_link_libraries(test_heroicjson PRIVATE
+    Qt6::Core
+    GTest::gtest
+    GTest::gtest_main
+)
+add_test(NAME test_heroicjson COMMAND test_heroicjson)
+
+# ---------------------------------------------------------------------------
+# Proton discovery tests (including Heroic without Steam)
+# ---------------------------------------------------------------------------
+add_executable(test_protondetection EXCLUDE_FROM_ALL
+    test_protondetection.cpp
+)
+set_target_properties(test_protondetection PROPERTIES
+    AUTOMOC OFF
+    CXX_STANDARD 23
+    CXX_STANDARD_REQUIRED ON
+)
+target_include_directories(test_protondetection PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/src
+)
+target_link_libraries(test_protondetection PRIVATE
+    Qt6::Core
+    mo2::uibase
+    GTest::gtest
+    GTest::gtest_main
+)
+add_test(NAME test_protondetection COMMAND test_protondetection)
+
+# ---------------------------------------------------------------------------
 # External directory mapping (SKSE Log Redirector style) tests
 #
 # Exercises the deploy/cleanup logic for `isDirectory && createTarget`
@@ -181,5 +225,5 @@ add_test(NAME test_staging_promotion COMMAND test_staging_promotion)
 # Register a "fluorine-tests" umbrella target that builds every test exe.
 add_custom_target(fluorine-tests
     DEPENDS test_esptk_tes3 test_plugincompatibility test_metainiutils
-            test_external_dir_mapping test_vfs_file_ops test_vfs_catalog
-            test_staging_promotion)
+            test_heroicjson test_protondetection test_external_dir_mapping
+            test_vfs_file_ops test_vfs_catalog test_staging_promotion)

--- a/src/tests/test_heroicjson.cpp
+++ b/src/tests/test_heroicjson.cpp
@@ -1,0 +1,91 @@
+#include "heroicjson.h"
+
+#include <gtest/gtest.h>
+
+TEST(HeroicJson, ParsesModernLibraryCache)
+{
+  const QByteArray json = R"json(
+    {
+      "library": [
+        {
+          "app_name": "Ginger",
+          "namespace": "77f2b98e2cef40c8a7437518bf420e47",
+          "title": "Cyberpunk 2077",
+          "is_installed": true,
+          "install": {
+            "install_path": "/games/Cyberpunk2077",
+            "platform": "Windows"
+          }
+        },
+        {
+          "app_name": "NotInstalled",
+          "title": "Not Installed",
+          "is_installed": false,
+          "install": {
+            "install_path": "/games/not-installed",
+            "platform": "Windows"
+          }
+        }
+      ]
+    }
+  )json";
+
+  const QVector<HeroicEpicInstall> installs = parseHeroicEpicInstalls(json);
+
+  ASSERT_EQ(installs.size(), 2);
+  EXPECT_EQ(installs[0].app_name, QStringLiteral("Ginger"));
+  EXPECT_EQ(installs[0].namespace_id,
+            QStringLiteral("77f2b98e2cef40c8a7437518bf420e47"));
+  EXPECT_EQ(installs[0].title, QStringLiteral("Cyberpunk 2077"));
+  EXPECT_EQ(installs[0].install_path, QStringLiteral("/games/Cyberpunk2077"));
+  EXPECT_EQ(installs[0].platform, QStringLiteral("Windows"));
+  EXPECT_TRUE(installs[0].is_installed);
+  EXPECT_FALSE(installs[1].is_installed);
+}
+
+TEST(HeroicJson, TreatsLegendaryInstalledEntriesAsInstalled)
+{
+  const QByteArray json = R"json(
+    {
+      "Ginger": {
+        "app_name": "Ginger",
+        "title": "Cyberpunk 2077",
+        "install_path": "/games/Cyberpunk2077",
+        "platform": "Windows"
+      }
+    }
+  )json";
+
+  const QVector<HeroicEpicInstall> installs = parseHeroicEpicInstalls(json);
+
+  ASSERT_EQ(installs.size(), 1);
+  EXPECT_EQ(installs[0].app_name, QStringLiteral("Ginger"));
+  EXPECT_EQ(installs[0].install_path, QStringLiteral("/games/Cyberpunk2077"));
+  EXPECT_EQ(installs[0].platform, QStringLiteral("Windows"));
+  EXPECT_TRUE(installs[0].is_installed);
+}
+
+TEST(HeroicJson, UsesObjectKeyWhenLegendaryOmitsAppName)
+{
+  const QByteArray json = R"json(
+    {
+      "FallbackName": {
+        "title": "Example",
+        "install_path": "/games/example",
+        "platform": "Windows"
+      }
+    }
+  )json";
+
+  const QVector<HeroicEpicInstall> installs = parseHeroicEpicInstalls(json);
+
+  ASSERT_EQ(installs.size(), 1);
+  EXPECT_EQ(installs[0].app_name, QStringLiteral("FallbackName"));
+  EXPECT_TRUE(installs[0].is_installed);
+}
+
+TEST(HeroicJson, RejectsMalformedOrUnexpectedDocuments)
+{
+  EXPECT_TRUE(parseHeroicEpicInstalls("{").isEmpty());
+  EXPECT_TRUE(parseHeroicEpicInstalls("[]").isEmpty());
+}

--- a/src/tests/test_heroicjson.cpp
+++ b/src/tests/test_heroicjson.cpp
@@ -14,7 +14,8 @@ TEST(HeroicJson, ParsesModernLibraryCache)
           "is_installed": true,
           "install": {
             "install_path": "/games/Cyberpunk2077",
-            "platform": "Windows"
+            "platform": "Windows",
+            "is_dlc": false
           }
         },
         {
@@ -40,7 +41,33 @@ TEST(HeroicJson, ParsesModernLibraryCache)
   EXPECT_EQ(installs[0].install_path, QStringLiteral("/games/Cyberpunk2077"));
   EXPECT_EQ(installs[0].platform, QStringLiteral("Windows"));
   EXPECT_TRUE(installs[0].is_installed);
+  EXPECT_FALSE(installs[0].is_dlc);
   EXPECT_FALSE(installs[1].is_installed);
+}
+
+TEST(HeroicJson, ParsesDlcFlagFromModernNestedInstall)
+{
+  const QByteArray json = R"json(
+    {
+      "library": [
+        {
+          "app_name": "CyberpunkDlc",
+          "title": "Cyberpunk 2077: Phantom Liberty",
+          "is_installed": true,
+          "install": {
+            "install_path": "/games/Cyberpunk2077",
+            "platform": "Windows",
+            "is_dlc": true
+          }
+        }
+      ]
+    }
+  )json";
+
+  const QVector<HeroicEpicInstall> installs = parseHeroicEpicInstalls(json);
+
+  ASSERT_EQ(installs.size(), 1);
+  EXPECT_TRUE(installs[0].is_dlc);
 }
 
 TEST(HeroicJson, TreatsLegendaryInstalledEntriesAsInstalled)
@@ -51,7 +78,8 @@ TEST(HeroicJson, TreatsLegendaryInstalledEntriesAsInstalled)
         "app_name": "Ginger",
         "title": "Cyberpunk 2077",
         "install_path": "/games/Cyberpunk2077",
-        "platform": "Windows"
+        "platform": "Windows",
+        "is_dlc": true
       }
     }
   )json";
@@ -63,6 +91,7 @@ TEST(HeroicJson, TreatsLegendaryInstalledEntriesAsInstalled)
   EXPECT_EQ(installs[0].install_path, QStringLiteral("/games/Cyberpunk2077"));
   EXPECT_EQ(installs[0].platform, QStringLiteral("Windows"));
   EXPECT_TRUE(installs[0].is_installed);
+  EXPECT_TRUE(installs[0].is_dlc);
 }
 
 TEST(HeroicJson, UsesObjectKeyWhenLegendaryOmitsAppName)

--- a/src/tests/test_heroicjson.cpp
+++ b/src/tests/test_heroicjson.cpp
@@ -70,6 +70,32 @@ TEST(HeroicJson, ParsesDlcFlagFromModernNestedInstall)
   EXPECT_TRUE(installs[0].is_dlc);
 }
 
+TEST(HeroicJson, InfersModernInstalledStateFromNestedInstallPath)
+{
+  const QByteArray json = R"json(
+    {
+      "library": [
+        {
+          "app_name": "Ginger",
+          "install": {
+            "install_path": "/games/Cyberpunk2077",
+            "platform": "Windows"
+          }
+        },
+        {
+          "app_name": "LibraryOnly"
+        }
+      ]
+    }
+  )json";
+
+  const QVector<HeroicEpicInstall> installs = parseHeroicEpicInstalls(json);
+
+  ASSERT_EQ(installs.size(), 2);
+  EXPECT_TRUE(installs[0].is_installed);
+  EXPECT_FALSE(installs[1].is_installed);
+}
+
 TEST(HeroicJson, TreatsLegendaryInstalledEntriesAsInstalled)
 {
   const QByteArray json = R"json(
@@ -111,6 +137,33 @@ TEST(HeroicJson, UsesObjectKeyWhenLegendaryOmitsAppName)
   ASSERT_EQ(installs.size(), 1);
   EXPECT_EQ(installs[0].app_name, QStringLiteral("FallbackName"));
   EXPECT_TRUE(installs[0].is_installed);
+}
+
+TEST(HeroicJson, MergesCacheMetadataWithoutReplacingManifestPath)
+{
+  HeroicEpicInstall manifest;
+  manifest.app_name     = QStringLiteral("Ginger");
+  manifest.title        = QStringLiteral("Ginger");
+  manifest.install_path = QStringLiteral("/games/current");
+  manifest.platform     = QStringLiteral("Windows");
+  manifest.is_installed = true;
+
+  HeroicEpicInstall cached;
+  cached.app_name     = QStringLiteral("Ginger");
+  cached.namespace_id = QStringLiteral("77f2b98e2cef40c8a7437518bf420e47");
+  cached.title        = QStringLiteral("Cyberpunk 2077");
+  cached.install_path = QStringLiteral("/games/stale");
+  cached.platform     = QStringLiteral("Windows");
+  cached.is_installed = true;
+
+  const QVector<HeroicEpicInstall> installs =
+      mergeHeroicEpicInstalls({manifest}, {cached});
+
+  ASSERT_EQ(installs.size(), 1);
+  EXPECT_EQ(installs[0].install_path, QStringLiteral("/games/current"));
+  EXPECT_EQ(installs[0].title, QStringLiteral("Cyberpunk 2077"));
+  EXPECT_EQ(installs[0].namespace_id,
+            QStringLiteral("77f2b98e2cef40c8a7437518bf420e47"));
 }
 
 TEST(HeroicJson, RejectsMalformedOrUnexpectedDocuments)

--- a/src/tests/test_protondetection.cpp
+++ b/src/tests/test_protondetection.cpp
@@ -5,6 +5,7 @@
 #include <QFileInfo>
 #include <QTemporaryDir>
 #include <gtest/gtest.h>
+#include <uibase/log.h>
 
 namespace
 {
@@ -16,7 +17,18 @@ void createFile(const QString& path)
 }
 }  // namespace
 
-TEST(ProtonDetection, FindsHeroicRunnerWithoutSteamLibraries)
+class ProtonDetection : public ::testing::Test
+{
+protected:
+  static void SetUpTestSuite()
+  {
+    MOBase::log::LoggerConfiguration configuration;
+    configuration.name = "test_protondetection";
+    MOBase::log::createDefault(configuration);
+  }
+};
+
+TEST_F(ProtonDetection, FindsHeroicRunnerWithoutSteamLibraries)
 {
   QTemporaryDir temporary;
   ASSERT_TRUE(temporary.isValid());
@@ -34,7 +46,7 @@ TEST(ProtonDetection, FindsHeroicRunnerWithoutSteamLibraries)
   EXPECT_FALSE(protons[0].is_steam_proton);
 }
 
-TEST(ProtonDetection, RejectsRunnerWithoutWineBinary)
+TEST_F(ProtonDetection, RejectsRunnerWithoutWineBinary)
 {
   QTemporaryDir temporary;
   ASSERT_TRUE(temporary.isValid());
@@ -45,7 +57,7 @@ TEST(ProtonDetection, RejectsRunnerWithoutWineBinary)
   EXPECT_TRUE(findProtonsForPaths({}, {temporary.path()}).isEmpty());
 }
 
-TEST(ProtonDetection, DeduplicatesCanonicalRunnerPaths)
+TEST_F(ProtonDetection, DeduplicatesCanonicalRunnerPaths)
 {
   QTemporaryDir temporary;
   ASSERT_TRUE(temporary.isValid());

--- a/src/tests/test_protondetection.cpp
+++ b/src/tests/test_protondetection.cpp
@@ -1,0 +1,61 @@
+#include "steamdetection.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QTemporaryDir>
+#include <gtest/gtest.h>
+
+namespace
+{
+void createFile(const QString& path)
+{
+  ASSERT_TRUE(QDir().mkpath(QFileInfo(path).absolutePath()));
+  QFile file(path);
+  ASSERT_TRUE(file.open(QIODevice::WriteOnly));
+}
+}  // namespace
+
+TEST(ProtonDetection, FindsHeroicRunnerWithoutSteamLibraries)
+{
+  QTemporaryDir temporary;
+  ASSERT_TRUE(temporary.isValid());
+
+  const QString runner = QDir(temporary.path()).filePath("GE-Proton-latest");
+  createFile(QDir(runner).filePath("proton"));
+  createFile(QDir(runner).filePath("files/bin/wine"));
+
+  const QVector<SteamProtonInfo> protons =
+      findProtonsForPaths({}, {temporary.path()});
+
+  ASSERT_EQ(protons.size(), 1);
+  EXPECT_EQ(protons[0].name, QStringLiteral("GE-Proton-latest"));
+  EXPECT_EQ(QDir::cleanPath(protons[0].path), QDir::cleanPath(runner));
+  EXPECT_FALSE(protons[0].is_steam_proton);
+}
+
+TEST(ProtonDetection, RejectsRunnerWithoutWineBinary)
+{
+  QTemporaryDir temporary;
+  ASSERT_TRUE(temporary.isValid());
+
+  const QString runner = QDir(temporary.path()).filePath("GE-Proton-latest");
+  createFile(QDir(runner).filePath("proton"));
+
+  EXPECT_TRUE(findProtonsForPaths({}, {temporary.path()}).isEmpty());
+}
+
+TEST(ProtonDetection, DeduplicatesCanonicalRunnerPaths)
+{
+  QTemporaryDir temporary;
+  ASSERT_TRUE(temporary.isValid());
+
+  const QString runner = QDir(temporary.path()).filePath("GE-Proton-latest");
+  createFile(QDir(runner).filePath("proton"));
+  createFile(QDir(runner).filePath("files/bin/wine"));
+
+  const QVector<SteamProtonInfo> protons =
+      findProtonsForPaths({}, {temporary.path(), temporary.path()});
+
+  ASSERT_EQ(protons.size(), 1);
+}


### PR DESCRIPTION
## Summary
- normalize both modern Heroic library caches and Legendary installed manifests for C++ game detection
- read both sources and deduplicate by launch app name so Heroic prefixes and registry metadata are imported
- discover native and Flatpak Heroic Proton runners without requiring a Steam installation
- add focused C++ regression tests for JSON schemas and Steam-independent Proton scanning

## Verified
- reproduced the modern cache shape and missing is_installed field from a real Heroic installation
- verified Cyberpunk 2077 resolves as app name Ginger with its nested Windows install path
- git diff --check passes
- local C++ execution is unavailable because this host lacks Qt/GTest development headers and has no container daemon; the repository PR workflow is the compile gate

Related to #77. Complements #133, which fixes Python Epic namespace lookup.