### PR TITLE
Added note to README regarding Runtime Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ new-generation publication remain serialized and crash-safe.
   - `libstdc++`
   - `libX11`
   - `libxkbcommon`
+  - `wayland` (if using wayland)
 
 On most distros these are already present or installable via your package manager.
 


### PR DESCRIPTION
This is mainly for NixOS. I have found that this is needed on most wayland window managers/desktops, excluding KDE's Plasma 6.