### PR TITLE
Fixed url() not resolving in stylehseets

### DIFF
--- a/src/src/moapplication.cpp
+++ b/src/src/moapplication.cpp
@@ -868,7 +868,7 @@ QString resolveStyleSheetUrl(const QString& url, const QString& baseDir)
     return trimmed;
   }
 
-  return QUrl::fromLocalFile(QDir(baseDir).absoluteFilePath(trimmed)).toString();
+  return QDir(baseDir).absoluteFilePath(trimmed);
 }
 
 QString resolveRelativeStyleSheetUrls(const QString& stylesheet,


### PR DESCRIPTION
QPixmap cannot resolve relative url() paths in QSS stylesheets. While one could use absolute file paths or URI's instead, it is much easier to just replace the existing return value resolveStyleSheetUrl from QUrl to QDir.

Note that I used claude to find where this issue was but did not use claude in generating the fix.