### PR TITLE
Fix window size restoration on wayland

### DIFF
--- a/src/src/mainwindow.cpp
+++ b/src/src/mainwindow.cpp
@@ -583,6 +583,16 @@ MainWindow::MainWindow(Settings& settings, OrganizerCore& organizerCore,
   ui->modList->updateModCount();
   ui->espList->updatePluginCount();
   ui->statusBar->updateNormalMessage(m_OrganizerCore);
+
+  // On Wayland the compositor owns the window position (it is never visible to
+  // the app, so the saved geometry's position is always 0,0), and geometry
+  // must be applied before the window is first shown.  Restore just the size
+  // and maximized state here; position stays compositor-managed.  On X11 the
+  // full geometry is restored later in readSettings().
+  if (QGuiApplication::platformName().startsWith(QStringLiteral("wayland"),
+                                                  Qt::CaseInsensitive)) {
+    m_OrganizerCore.settings().geometry().restoreWindowSize(this);
+  }
 }
 
 void MainWindow::setupModList()
@@ -2388,6 +2398,7 @@ void MainWindow::storeSettings()
 
   s.geometry().saveState(this);
   s.geometry().saveGeometry(this);
+  s.geometry().saveWindowSize(this);
   s.geometry().saveDocks(this);
 
   s.geometry().saveVisibility(ui->statusBar);

--- a/src/src/settings.cpp
+++ b/src/src/settings.cpp
@@ -776,6 +776,45 @@ bool GeometrySettings::restoreWindowGeometry(QWidget* w) const
   return false;
 }
 
+void GeometrySettings::saveWindowSize(const QMainWindow* w) const
+{
+  // when maximized we still want the restored (normal) size, matching what
+  // saveGeometry() would store
+  const QSize size = w->isMaximized() ? w->normalGeometry().size() : w->size();
+  set(m_Settings, "Geometry", geoSettingName(w) + "_size",
+      QString("%1x%2").arg(size.width()).arg(size.height()));
+  set(m_Settings, "Geometry", geoSettingName(w) + "_maximized", w->isMaximized());
+}
+
+bool GeometrySettings::restoreWindowSize(QMainWindow* w) const
+{
+  const QString base = geoSettingName(w);
+
+  bool parsed = false;
+  int width  = 0;
+  int height = 0;
+  if (auto v = getOptional<QString>(m_Settings, "Geometry", base + "_size")) {
+    const int x = v->section(QLatin1Char('x'), 0, 0).toInt(&parsed);
+    const int y = v->section(QLatin1Char('x'), 1, 1).toInt();
+    if (parsed && y > 0) {
+      width  = x;
+      height = y;
+    } else {
+      parsed = false;
+    }
+  }
+
+  if (parsed) {
+    w->resize(width, height);
+  }
+
+  if (getOptional<bool>(m_Settings, "Geometry", base + "_maximized").value_or(false)) {
+    w->showMaximized();
+  }
+
+  return parsed;
+}
+
 void GeometrySettings::ensureWindowOnScreen(QWidget* w)
 {
   // users report that the main window and/or dialogs are displayed off-screen;

--- a/src/src/settings.h
+++ b/src/src/settings.h
@@ -111,6 +111,9 @@ public:
   void saveGeometry(const QMainWindow* w);
   bool restoreGeometry(QMainWindow* w) const;
 
+  void saveWindowSize(const QMainWindow* w) const;
+  bool restoreWindowSize(QMainWindow* w) const;
+
   void saveGeometry(const QDialog* d);
   bool restoreGeometry(QDialog* d) const;
 


### PR DESCRIPTION
I tend to use Fluorine maximized, and I've noticed that it doesn't seem to restore the size from previous runs when I open it. From looking into this, Wayland seems to be kinda weird about restoring window state; it seems to completely hide the position of windows from apps (making it impossible to restore that; I tried resizing Firefox to a small rectangle in the middle of my screen and restarted it, and it kept the size but put it at the top-left corner, so if even Firefox can't restore position, it's probably a good sign that it's not easily solvable), and I suspect that window size is expected to be saved by apps manually to restore.

From trying it out locally, manually saving the size/maximization state in the settings and then manually restoring it when the app opens seems to work the way I'd expect.